### PR TITLE
Enable ThunderGate cache auto invalidation

### DIFF
--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/Constants.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/Constants.java
@@ -80,7 +80,7 @@ public final class Constants {
      */
     public static final Set<String> SYSTEM_TABLE_NAMES;
     static {
-        Set<String> set = new TreeSet<String>();
+        Set<String> set = new TreeSet<>();
         set.add("RUNNING_JOBFLOWS");
         set.add("IMPORT_TABLE_LOCK");
         set.add("IMPORT_RECORD_LOCK");

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/Main.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/Main.java
@@ -324,13 +324,10 @@ public final class Main {
     private static Properties loadProperties(String path) throws IOException {
         assert path != null;
         LOG.debug("Loading Properties: {}", path);
-        InputStream in = new FileInputStream(path);
-        try {
+        try (InputStream in = new FileInputStream(path)) {
             Properties result = new Properties();
             result.load(in);
             return result;
-        } finally {
-            in.close();
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/driver/CacheSupportEmitter.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/driver/CacheSupportEmitter.java
@@ -86,6 +86,7 @@ public class CacheSupportEmitter extends JavaDataModelDriver {
         results.add(createModelVersionMethod(context, model, trait));
         results.add(createTimestampColumnMethod(context, model, trait.getTimestamp()));
         results.add(createSystemIdMethod(context, model, trait.getSid()));
+        results.add(createTimestampMethod(context, model, trait.getTimestamp()));
         results.add(createDeletedMethod(context, model, trait.getDeleteFlag()));
         return results;
     }
@@ -215,6 +216,31 @@ public class CacheSupportEmitter extends JavaDataModelDriver {
                     .toAttributes(),
                 context.resolve(long.class),
                 f.newSimpleName("__tgc__SystemId"),
+                Collections.<FormalParameterDeclaration>emptyList(),
+                statements);
+    }
+
+    private MethodDeclaration createTimestampMethod(
+            EmitContext context,
+            ModelDeclaration model,
+            PropertySymbol timestamp) {
+        assert context != null;
+        assert model != null;
+        assert timestamp != null;
+        ModelFactory f = context.getModelFactory();
+        List<Statement> statements = Lists.create();
+        statements.add(new ExpressionBuilder(f, f.newThis())
+                .method(context.getValueGetterName(timestamp.findDeclaration()))
+                .method("getElapsedSeconds")
+                .toReturnStatement());
+        return f.newMethodDeclaration(
+                null,
+                new AttributeBuilder(f)
+                .annotation(context.resolve(Override.class))
+                .Public()
+                .toAttributes(),
+                context.resolve(long.class),
+                f.newSimpleName("__tgc__Timestamp"),
                 Collections.<FormalParameterDeclaration>emptyList(),
                 statements);
     }

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/JoinedModelGenerator.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/JoinedModelGenerator.java
@@ -60,7 +60,7 @@ public final class JoinedModelGenerator {
         if (model == null) {
             throw new IllegalArgumentException("model must not be null"); //$NON-NLS-1$
         }
-        return new AstModelDefinition<AstJoin>(
+        return new AstModelDefinition<>(
                 null,
                 ModelDefinitionKind.JOINED,
                 AstBuilder.getDesciption(
@@ -79,7 +79,7 @@ public final class JoinedModelGenerator {
     private AstExpression<AstJoin> generateExpression() {
         AstJoin from = generateTerm(model.getFromModel(), model.getFromCondition(), true);
         AstJoin join = generateTerm(model.getJoinModel(), model.getJoinCondition(), false);
-        return new AstUnionExpression<AstJoin>(null, Arrays.asList(from, join));
+        return new AstUnionExpression<>(null, Arrays.asList(from, join));
     }
 
     private AstJoin generateTerm(ModelReference sourceModel, List<Source> group, boolean from) {

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/RecordLockDdlEmitter.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/RecordLockDdlEmitter.java
@@ -41,19 +41,14 @@ public class RecordLockDdlEmitter {
 
     private static final String TEMPLATE_CONTENTS;
     static {
-        InputStream in = RecordLockDdlEmitter.class.getResourceAsStream(TEMPLATE_FILE);
-        try {
-            try {
-                TEMPLATE_CONTENTS = IOUtils.toString(in, ENCODING);
-            } finally {
-                in.close();
-            }
+        try (InputStream in = RecordLockDdlEmitter.class.getResourceAsStream(TEMPLATE_FILE)) {
+            TEMPLATE_CONTENTS = IOUtils.toString(in, ENCODING);
         } catch (IOException e) {
             throw new IOError(e);
         }
     }
 
-    private final Set<String> tableNames = new TreeSet<String>();
+    private final Set<String> tableNames = new TreeSet<>();
 
     /**
      * Adds a table to this generator.

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/RecordModelGenerator.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/RecordModelGenerator.java
@@ -79,7 +79,7 @@ public final class RecordModelGenerator {
         attrs.add(AstBuilder.getPrimaryKey(model));
         Collections.addAll(attrs, extra);
 
-        return new AstModelDefinition<AstRecord>(
+        return new AstModelDefinition<>(
                 null,
                 ModelDefinitionKind.RECORD,
                 AstBuilder.getDesciption("テーブル{0}", model.getReference().getSimpleName()),

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/SummarizedModelGenerator.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/SummarizedModelGenerator.java
@@ -58,7 +58,7 @@ public final class SummarizedModelGenerator {
         if (model == null) {
             throw new IllegalArgumentException("model must not be null"); //$NON-NLS-1$
         }
-        return new AstModelDefinition<AstSummarize>(
+        return new AstModelDefinition<>(
                 null,
                 ModelDefinitionKind.SUMMARIZED,
                 AstBuilder.getDesciption(

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/ThunderGateModelEmitter.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/emitter/ThunderGateModelEmitter.java
@@ -107,7 +107,7 @@ public class ThunderGateModelEmitter {
             return null;
         }
 
-        Map<String, ModelProperty> properties = new TreeMap<String, ModelProperty>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, ModelProperty> properties = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (ModelProperty property : model.getProperties()) {
             properties.put(property.getSource().getName(), property);
         }
@@ -182,16 +182,13 @@ public class ThunderGateModelEmitter {
     private void emit(String name, AstScript script) throws IOException {
         assert name != null;
         assert script != null;
-        PrintWriter output = open(name);
-        try {
+        try (PrintWriter output = open(name)) {
             DmdlEmitter.emit(script, output);
             if (output.checkError()) {
                 throw new IOException(MessageFormat.format(
                         "Cannot output DMDL {0}",
                         name));
             }
-        } finally {
-            output.close();
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/model/ModelRepository.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/model/ModelRepository.java
@@ -29,7 +29,7 @@ import com.asakusafw.utils.collections.Maps;
 public class ModelRepository {
 
     private final LinkedHashMap<ModelReference, ModelDescription> models =
-        new LinkedHashMap<ModelReference, ModelDescription>();
+        new LinkedHashMap<>();
 
     private final Map<String, ModelDescription> simpleNames = Maps.create();
 

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/util/JoinedModelBuilder.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/util/JoinedModelBuilder.java
@@ -164,7 +164,7 @@ public class JoinedModelBuilder extends ModelBuilder<JoinedModelBuilder> {
 
     private List<ModelProperty> buildProperties() {
         // ペア用のコンテナを作成
-        Map<String, SourcePair> pairs = new TreeMap<String, SourcePair>();
+        Map<String, SourcePair> pairs = new TreeMap<>();
         for (String mapTo : columns) {
             pairs.put(mapTo, new SourcePair());
         }
@@ -260,10 +260,10 @@ public class JoinedModelBuilder extends ModelBuilder<JoinedModelBuilder> {
         Side(ModelDescription model) {
             assert model != null;
             this.model = model;
-            this.sources = new TreeMap<String, Source>();
+            this.sources = new TreeMap<>();
             this.alias = model.getReference().getSimpleName();
             this.condition = Lists.create();
-            this.mapping = new TreeMap<String, String>();
+            this.mapping = new TreeMap<>();
             for (Source s : model.getPropertiesAsSources()) {
                 sources.put(s.getName(), s);
                 mapping.put(s.getName(), null);

--- a/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/util/SummarizedModelBuilder.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/main/java/com/asakusafw/dmdl/thundergate/util/SummarizedModelBuilder.java
@@ -57,7 +57,7 @@ public class SummarizedModelBuilder extends ModelBuilder<SummarizedModelBuilder>
             String alias) {
         super(tableName);
         this.alias = (alias == null) ? model.getReference().getSimpleName() : alias;
-        this.sources = new TreeMap<String, Source>();
+        this.sources = new TreeMap<>();
         this.groupProperties = Lists.create();
         this.columns = Lists.create();
         for (Source s : model.getPropertiesAsSources()) {
@@ -170,7 +170,7 @@ public class SummarizedModelBuilder extends ModelBuilder<SummarizedModelBuilder>
         if (groupProperties.isEmpty()) {
             return;
         }
-        Set<String> rest = new LinkedHashSet<String>();
+        Set<String> rest = new LinkedHashSet<>();
         for (Source source : groupProperties) {
             rest.add(source.getName());
         }

--- a/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/GeneratorTesterRoot.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/GeneratorTesterRoot.java
@@ -95,16 +95,13 @@ public class GeneratorTesterRoot {
     protected void emitDmdl(AstModelDefinition<?> model) {
         AstScript script = new AstScript(null, Collections.singletonList(model));
         StringWriter buffer = new StringWriter();
-        PrintWriter output = new PrintWriter(buffer);
-        DmdlEmitter.emit(script, output);
-        output.close();
+        try (PrintWriter output = new PrintWriter(buffer)) {
+            DmdlEmitter.emit(script, output);
+        }
         try {
             File file = folder.newFile(model.name.identifier + ".dmdl");
-            PrintWriter writer = new PrintWriter(file, "UTF-8");
-            try {
+            try (PrintWriter writer = new PrintWriter(file, "UTF-8")) {
                 writer.print(buffer.toString());
-            } finally {
-                writer.close();
             }
         } catch (IOException e) {
             throw new AssertionError(e);

--- a/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/MainTest.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/MainTest.java
@@ -235,11 +235,8 @@ public class MainTest {
 
     private File jdbc(Properties jdbcProperties) throws IOException {
         File jdbc = folder.newFile("jdbc.properties");
-        FileOutputStream out = new FileOutputStream(jdbc);
-        try {
+        try (FileOutputStream out = new FileOutputStream(jdbc)) {
             jdbcProperties.store(out, "testing");
-        } finally {
-            out.close();
         }
         return jdbc;
     }

--- a/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/driver/CacheSupportEmitterTest.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/driver/CacheSupportEmitterTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.asakusafw.dmdl.thundergate.GeneratorTesterRoot;
+import com.asakusafw.runtime.value.DateTime;
 import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
 
 /**
@@ -51,7 +52,9 @@ public class CacheSupportEmitterTest extends GeneratorTesterRoot {
         ThunderGateCacheSupport support = (ThunderGateCacheSupport) model.unwrap();
 
         model.set("sid", 100L);
+        model.set("last_updt_datetime", timestamp(200L));
         assertThat(support.__tgc__SystemId(), is(100L));
+        assertThat(support.__tgc__Timestamp(), is(200L));
         assertThat(support.__tgc__TimestampColumn(), is("LAST_UPDT_DATETIME"));
         assertThat(support.__tgc__Deleted(), is(false));
     }
@@ -187,5 +190,9 @@ public class CacheSupportEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_cache_type_integer() {
         shouldSemanticError("invalid_cache_type_integer");
+    }
+
+    private static DateTime timestamp(long time) {
+        return new DateTime(time);
     }
 }

--- a/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/driver/ModelInputDriverTest.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/driver/ModelInputDriverTest.java
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 import com.asakusafw.dmdl.java.emitter.driver.ObjectDriver;
 import com.asakusafw.dmdl.thundergate.GeneratorTesterRoot;
-import com.asakusafw.dmdl.thundergate.driver.ModelInputDriver;
-import com.asakusafw.dmdl.thundergate.driver.ModelOutputDriver;
 import com.asakusafw.runtime.io.ModelInput;
 import com.asakusafw.runtime.io.ModelOutput;
 import com.asakusafw.runtime.io.RecordEmitter;
@@ -74,46 +72,45 @@ public class ModelInputDriverTest extends GeneratorTesterRoot {
 
         ModelWrapper object = loader.newModel("Simple");
         DataOutputBuffer output = new DataOutputBuffer();
-        ModelOutput<Object> modelOut = (ModelOutput<Object>) type.getAnnotation(ModelOutputLocation.class)
-            .value()
-            .getDeclaredConstructor(RecordEmitter.class)
-            .newInstance(new TsvEmitter(new OutputStreamWriter(output, "UTF-8")));
+        try (ModelOutput<Object> modelOut = (ModelOutput<Object>) type.getAnnotation(ModelOutputLocation.class)
+                .value()
+                .getDeclaredConstructor(RecordEmitter.class)
+                .newInstance(new TsvEmitter(new OutputStreamWriter(output, "UTF-8")))) {
+            object.set("sid", 1L);
+            object.set("value", new Text("hello"));
+            modelOut.write(object.unwrap());
 
-        object.set("sid", 1L);
-        object.set("value", new Text("hello"));
-        modelOut.write(object.unwrap());
+            object.set("sid", 2L);
+            object.set("value", new Text("world"));
+            modelOut.write(object.unwrap());
 
-        object.set("sid", 2L);
-        object.set("value", new Text("world"));
-        modelOut.write(object.unwrap());
-
-        object.set("sid", 3L);
-        object.set("value", null);
-        modelOut.write(object.unwrap());
-        modelOut.close();
+            object.set("sid", 3L);
+            object.set("value", null);
+            modelOut.write(object.unwrap());
+        }
 
         DataInputBuffer input = new DataInputBuffer();
         input.reset(output.getData(), output.getLength());
-        ModelInput<Object> modelIn = (ModelInput<Object>) type.getAnnotation(ModelInputLocation.class)
-            .value()
-            .getDeclaredConstructor(RecordParser.class)
-            .newInstance(new TsvParser(new InputStreamReader(input, "UTF-8")));
-        ModelWrapper copy = loader.newModel("Simple");
+        try (ModelInput<Object> modelIn = (ModelInput<Object>) type.getAnnotation(ModelInputLocation.class)
+                .value()
+                .getDeclaredConstructor(RecordParser.class)
+                .newInstance(new TsvParser(new InputStreamReader(input, "UTF-8")))) {
+            ModelWrapper copy = loader.newModel("Simple");
 
-        modelIn.readTo(copy.unwrap());
-        assertThat(copy.get("sid"), is((Object) 1L));
-        assertThat(copy.get("value"), is((Object) new Text("hello")));
+            modelIn.readTo(copy.unwrap());
+            assertThat(copy.get("sid"), is((Object) 1L));
+            assertThat(copy.get("value"), is((Object) new Text("hello")));
 
-        modelIn.readTo(copy.unwrap());
-        assertThat(copy.get("sid"), is((Object) 2L));
-        assertThat(copy.get("value"), is((Object) new Text("world")));
+            modelIn.readTo(copy.unwrap());
+            assertThat(copy.get("sid"), is((Object) 2L));
+            assertThat(copy.get("value"), is((Object) new Text("world")));
 
-        modelIn.readTo(copy.unwrap());
-        assertThat(copy.get("sid"), is((Object) 3L));
-        assertThat(copy.getOption("value").isNull(), is(true));
+            modelIn.readTo(copy.unwrap());
+            assertThat(copy.get("sid"), is((Object) 3L));
+            assertThat(copy.getOption("value").isNull(), is(true));
 
-        assertThat(input.read(), is(-1));
-        modelIn.close();
+            assertThat(input.read(), is(-1));
+        }
     }
 
     /**
@@ -144,25 +141,25 @@ public class ModelInputDriverTest extends GeneratorTesterRoot {
         object.set("type_datetime", new DateTime(2011, 3, 31, 23, 30, 1));
 
         DataOutputBuffer output = new DataOutputBuffer();
-        ModelOutput<Object> modelOut = (ModelOutput<Object>) type.getAnnotation(ModelOutputLocation.class)
-            .value()
-            .getDeclaredConstructor(RecordEmitter.class)
-            .newInstance(new TsvEmitter(new OutputStreamWriter(output, "UTF-8")));
-        modelOut.write(object.unwrap());
-        modelOut.write(object.unwrap());
-        modelOut.write(object.unwrap());
-        modelOut.close();
+        try (ModelOutput<Object> modelOut = (ModelOutput<Object>) type.getAnnotation(ModelOutputLocation.class)
+                .value()
+                .getDeclaredConstructor(RecordEmitter.class)
+                .newInstance(new TsvEmitter(new OutputStreamWriter(output, "UTF-8")))) {
+            modelOut.write(object.unwrap());
+            modelOut.write(object.unwrap());
+            modelOut.write(object.unwrap());
+        }
 
         DataInputBuffer input = new DataInputBuffer();
         input.reset(output.getData(), output.getLength());
-        ModelInput<Object> modelIn = (ModelInput<Object>) type.getAnnotation(ModelInputLocation.class)
-            .value()
-            .getDeclaredConstructor(RecordParser.class)
-            .newInstance(new TsvParser(new InputStreamReader(input, "UTF-8")));
-        ModelWrapper copy = loader.newModel("Primitives");
-        modelIn.readTo(copy.unwrap());
-        assertThat(object.unwrap(), equalTo(copy.unwrap()));
-        assertThat(input.read(), is(-1));
-        modelIn.close();
+        try (ModelInput<Object> modelIn = (ModelInput<Object>) type.getAnnotation(ModelInputLocation.class)
+                .value()
+                .getDeclaredConstructor(RecordParser.class)
+                .newInstance(new TsvParser(new InputStreamReader(input, "UTF-8")))) {
+            ModelWrapper copy = loader.newModel("Primitives");
+            modelIn.readTo(copy.unwrap());
+            assertThat(object.unwrap(), equalTo(copy.unwrap()));
+            assertThat(input.read(), is(-1));
+        }
     }
 }

--- a/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/util/TableModelBuilderTest.java
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/test/java/com/asakusafw/dmdl/thundergate/util/TableModelBuilderTest.java
@@ -124,7 +124,8 @@ public class TableModelBuilderTest {
         assertThat(bAttr.containsAll(list(Attribute.UNIQUE, Attribute.NOT_NULL)), is(true));
     }
 
-    private <T> List<T> list(T... values) {
+    @SafeVarargs
+    private static <T> List<T> list(T... values) {
         return Arrays.asList(values);
     }
 }

--- a/thundergate-project/asakusa-thundergate-plugin/src/main/java/com/asakusafw/compiler/bulkloader/BulkLoaderIoProcessor.java
+++ b/thundergate-project/asakusa-thundergate-plugin/src/main/java/com/asakusafw/compiler/bulkloader/BulkLoaderIoProcessor.java
@@ -196,7 +196,7 @@ public class BulkLoaderIoProcessor extends ExternalIoDescriptionProcessor {
     private Set<String> diff(Collection<String> a, Collection<String> b) {
         assert a != null;
         assert b != null;
-        Set<String> diff = new TreeSet<String>(a);
+        Set<String> diff = new TreeSet<>(a);
         diff.removeAll(b);
         return diff;
     }
@@ -509,11 +509,8 @@ public class BulkLoaderIoProcessor extends ExternalIoDescriptionProcessor {
     private void emitProperties(String path, Properties properties) throws IOException {
         assert path != null;
         assert properties != null;
-        OutputStream output = getEnvironment().openResource(null, path);
-        try {
+        try (OutputStream output = getEnvironment().openResource(null, path)) {
             properties.store(output, getEnvironment().getTargetId());
-        } finally {
-            output.close();
         }
     }
 
@@ -536,8 +533,8 @@ public class BulkLoaderIoProcessor extends ExternalIoDescriptionProcessor {
     @Override
     public ExternalIoCommandProvider createCommandProvider(IoContext context) {
         String primary = null;
-        Map<String, IoContextBuilder> targets = new TreeMap<String, IoContextBuilder>();
-        Map<String, IoContextBuilder> caches = new TreeMap<String, IoContextBuilder>();
+        Map<String, IoContextBuilder> targets = new TreeMap<>();
+        Map<String, IoContextBuilder> caches = new TreeMap<>();
         for (Input input : context.getInputs()) {
             BulkLoadImporterDescription desc = extract(input.getDescription());
             String target = desc.getTargetName();
@@ -584,7 +581,7 @@ public class BulkLoaderIoProcessor extends ExternalIoDescriptionProcessor {
     }
 
     private Map<String, IoContext> build(Map<String, IoContextBuilder> builders) {
-        Map<String, IoContext> results = new TreeMap<String, IoContext>();
+        Map<String, IoContext> results = new TreeMap<>();
         for (Map.Entry<String, IoContextBuilder> entry : builders.entrySet()) {
             results.put(entry.getKey(), entry.getValue().build());
         }

--- a/thundergate-project/asakusa-thundergate-plugin/src/test/java/com/asakusafw/compiler/bulkloader/BulkLoaderIoProcessorRunTest.java
+++ b/thundergate-project/asakusa-thundergate-plugin/src/test/java/com/asakusafw/compiler/bulkloader/BulkLoaderIoProcessorRunTest.java
@@ -80,7 +80,7 @@ public class BulkLoaderIoProcessorRunTest {
                 return Ex1.class;
             }
         });
-        JobflowInfo info = tester.compileFlow(new IdentityFlow<Ex1>(in, out));
+        JobflowInfo info = tester.compileFlow(new IdentityFlow<>(in, out));
 
         BulkLoaderScript script = loadScript(info);
         assertThat(script.getImportTargetTables().size(), is(1));
@@ -90,18 +90,18 @@ public class BulkLoaderIoProcessorRunTest {
         ExportTable etable = script.getExportTargetTables().get(0);
         assertThat(etable.getSources().size(), is(1));
 
-        ModelOutput<Ex1> source = tester.openOutput(Ex1.class, itable.getDestination());
-        Ex1 ex1 = new Ex1();
-        ex1.setSid(200);
-        ex1.setValue(1);
-        source.write(ex1);
-        ex1.setSid(300);
-        ex1.setValue(2);
-        source.write(ex1);
-        ex1.setSid(100);
-        ex1.setValue(3);
-        source.write(ex1);
-        source.close();
+        try (ModelOutput<Ex1> source = tester.openOutput(Ex1.class, itable.getDestination())) {
+            Ex1 ex1 = new Ex1();
+            ex1.setSid(200);
+            ex1.setValue(1);
+            source.write(ex1);
+            ex1.setSid(300);
+            ex1.setValue(2);
+            source.write(ex1);
+            ex1.setSid(100);
+            ex1.setValue(3);
+            source.write(ex1);
+        }
 
         assertThat(tester.runStages(info), is(true));
 
@@ -153,7 +153,7 @@ public class BulkLoaderIoProcessorRunTest {
                 return Ex1.class;
             }
         });
-        JobflowInfo info = tester.compileFlow(new IdentityFlow<Ex1>(in, out));
+        JobflowInfo info = tester.compileFlow(new IdentityFlow<>(in, out));
 
         BulkLoaderScript script = loadScript(info);
         assertThat(script.getImportTargetTables().size(), is(1));
@@ -163,18 +163,18 @@ public class BulkLoaderIoProcessorRunTest {
         ExportTable etable = script.getExportTargetTables().get(0);
         assertThat(etable.getSources().size(), is(1));
 
-        ModelOutput<Ex1> source = tester.openOutput(Ex1.class, itable.getDestination());
-        Ex1 ex1 = new Ex1();
-        ex1.setSid(200);
-        ex1.setValue(1);
-        source.write(ex1);
-        ex1.setSid(300);
-        ex1.setValue(2);
-        source.write(ex1);
-        ex1.setSid(100);
-        ex1.setValue(3);
-        source.write(ex1);
-        source.close();
+        try (ModelOutput<Ex1> source = tester.openOutput(Ex1.class, itable.getDestination())) {
+            Ex1 ex1 = new Ex1();
+            ex1.setSid(200);
+            ex1.setValue(1);
+            source.write(ex1);
+            ex1.setSid(300);
+            ex1.setValue(2);
+            source.write(ex1);
+            ex1.setSid(100);
+            ex1.setValue(3);
+            source.write(ex1);
+        }
 
         assertThat(tester.runStages(info), is(true));
 
@@ -197,20 +197,14 @@ public class BulkLoaderIoProcessorRunTest {
     }
 
     private BulkLoaderScript loadScript(JobflowInfo info) throws IOException {
-        PropertyLoader loader = new PropertyLoader(info.getPackageFile(), "default");
-        BulkLoaderScript script;
-        try {
+        try (PropertyLoader loader = new PropertyLoader(info.getPackageFile(), "default")) {
             List<ImportTable> importers = ImportTable.fromProperties(
                     loader.loadImporterProperties(),
                     getClass().getClassLoader());
             List<ExportTable> exporters = ExportTable.fromProperties(
                     loader.loadExporterProperties(),
                     getClass().getClassLoader());
-            script = new BulkLoaderScript(importers, exporters);
-        } finally {
-            loader.close();
+            return new BulkLoaderScript(importers, exporters);
         }
-        return script;
     }
-
 }

--- a/thundergate-project/asakusa-thundergate-plugin/src/test/java/com/asakusafw/compiler/bulkloader/BulkLoaderIoProcessorTest.java
+++ b/thundergate-project/asakusa-thundergate-plugin/src/test/java/com/asakusafw/compiler/bulkloader/BulkLoaderIoProcessorTest.java
@@ -74,7 +74,7 @@ public class BulkLoaderIoProcessorTest {
         In<Ex1> in2 = flow.createIn("in2", new Import(Mode.PRIMARY, "default", LockType.ROW_OR_SKIP));
         Out<Ex1> out1 = flow.createOut("out1", new Export("default"));
         Out<Ex1> out2 = flow.createOut("out2", new Export("default"));
-        FlowDescription desc = new DualIdentityFlow<Ex1>(in1, in2, out1, out2);
+        FlowDescription desc = new DualIdentityFlow<>(in1, in2, out1, out2);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -126,7 +126,7 @@ public class BulkLoaderIoProcessorTest {
                 return Arrays.asList("A");
             }
         });
-        FlowDescription desc = new IdentityFlow<Ex1>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -182,7 +182,7 @@ public class BulkLoaderIoProcessorTest {
                 return Arrays.asList("B", "C");
             }
         });
-        FlowDescription desc = new IdentityFlow<MockUnionModel>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -230,7 +230,7 @@ public class BulkLoaderIoProcessorTest {
                 return Arrays.asList("B", "C");
             }
         });
-        FlowDescription desc = new IdentityFlow<MockUnionModel>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -274,7 +274,7 @@ public class BulkLoaderIoProcessorTest {
                 return Arrays.asList("UNKNOWN");
             }
         });
-        FlowDescription desc = new IdentityFlow<MockUnionModel>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -291,7 +291,7 @@ public class BulkLoaderIoProcessorTest {
         In<Ex1> in2 = flow.createIn("in2", new Import(Mode.SECONDARY, "secondary", LockType.UNUSED));
         Out<Ex1> out1 = flow.createOut("out1", new Export("default"));
         Out<Ex1> out2 = flow.createOut("out2", new Export("default"));
-        FlowDescription desc = new DualIdentityFlow<Ex1>(in1, in2, out1, out2);
+        FlowDescription desc = new DualIdentityFlow<>(in1, in2, out1, out2);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -314,7 +314,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Ex1> in1 = flow.createIn("in1", new DirectImporterDescription(Ex1.class, "a/a"));
         Out<Ex1> out1 = flow.createOut("out1", new Export("primary"));
-        FlowDescription desc = new IdentityFlow<Ex1>(in1, out1);
+        FlowDescription desc = new IdentityFlow<>(in1, out1);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -337,7 +337,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Ex1> in1 = flow.createIn("in1", new Import(Mode.PRIMARY, "primary", LockType.TABLE));
         Out<Ex1> out1 = flow.createOut("out1", new DirectExporterDescription(Ex1.class, "a/a-*"));
-        FlowDescription desc = new IdentityFlow<Ex1>(in1, out1);
+        FlowDescription desc = new IdentityFlow<>(in1, out1);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -360,7 +360,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Ex1> in1 = flow.createIn("in1", new Import(Mode.SECONDARY, "secondary", LockType.UNUSED));
         Out<Ex1> out1 = flow.createOut("out1", new DirectExporterDescription(Ex1.class, "a/a-*"));
-        FlowDescription desc = new IdentityFlow<Ex1>(in1, out1);
+        FlowDescription desc = new IdentityFlow<>(in1, out1);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -383,7 +383,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Ex1> in1 = flow.createIn("in1", new Import(Mode.SECONDARY, "secondary", LockType.ROW));
         Out<Ex1> out1 = flow.createOut("out1", new Export("primary"));
-        FlowDescription desc = new IdentityFlow<Ex1>(in1, out1);
+        FlowDescription desc = new IdentityFlow<>(in1, out1);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -400,7 +400,7 @@ public class BulkLoaderIoProcessorTest {
         In<Ex1> in2 = flow.createIn("in2", new Import(Mode.PRIMARY, "p2", LockType.ROW));
         Out<Ex1> out1 = flow.createOut("out1", new Export("p1"));
         Out<Ex1> out2 = flow.createOut("out2", new Export("p1"));
-        FlowDescription desc = new DualIdentityFlow<Ex1>(in1, in2, out1, out2);
+        FlowDescription desc = new DualIdentityFlow<>(in1, in2, out1, out2);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -417,7 +417,7 @@ public class BulkLoaderIoProcessorTest {
         In<Ex1> in2 = flow.createIn("in2", new Import(Mode.PRIMARY, "a", LockType.ROW));
         Out<Ex1> out1 = flow.createOut("out1", new Export("b"));
         Out<Ex1> out2 = flow.createOut("out2", new Export("b"));
-        FlowDescription desc = new DualIdentityFlow<Ex1>(in1, in2, out1, out2);
+        FlowDescription desc = new DualIdentityFlow<>(in1, in2, out1, out2);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -434,7 +434,7 @@ public class BulkLoaderIoProcessorTest {
         In<Ex1> in2 = flow.createIn("in2", new Import(Mode.PRIMARY, "a", LockType.ROW));
         Out<Ex1> out1 = flow.createOut("out1", new Export("a"));
         Out<Ex1> out2 = flow.createOut("out2", new Export("b"));
-        FlowDescription desc = new DualIdentityFlow<Ex1>(in1, in2, out1, out2);
+        FlowDescription desc = new DualIdentityFlow<>(in1, in2, out1, out2);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -451,7 +451,7 @@ public class BulkLoaderIoProcessorTest {
         In<Ex1> in2 = flow.createIn("in2", new Import(Mode.SECONDARY, "a", LockType.UNUSED));
         Out<Ex1> out1 = flow.createOut("out1", new Export("a"));
         Out<Ex1> out2 = flow.createOut("out2", new Export("a"));
-        FlowDescription desc = new DualIdentityFlow<Ex1>(in1, in2, out1, out2);
+        FlowDescription desc = new DualIdentityFlow<>(in1, in2, out1, out2);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -474,7 +474,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.UNUSED, null, DataSize.UNKNOWN));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -497,7 +497,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.UNUSED, "SID > 0", DataSize.UNKNOWN));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -512,7 +512,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.UNUSED, null, DataSize.UNKNOWN, Ex1.class));
         Out<Cached> out = flow.createOut("out1", new Export("default", Ex1.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -527,7 +527,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.TABLE, null, DataSize.UNKNOWN));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -542,7 +542,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.CHECK, null, DataSize.UNKNOWN));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));
@@ -557,7 +557,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.ROW, null, DataSize.UNKNOWN));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -572,7 +572,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.ROW_OR_SKIP, null, DataSize.UNKNOWN));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -587,7 +587,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.UNUSED, null, DataSize.TINY));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -602,7 +602,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.UNUSED, null, DataSize.SMALL));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, is(nullValue()));
@@ -617,7 +617,7 @@ public class BulkLoaderIoProcessorTest {
         FlowDescriptionDriver flow = new FlowDescriptionDriver();
         In<Cached> in = flow.createIn("in1", new ImportCached("default", LockType.UNUSED, null, DataSize.LARGE));
         Out<Cached> out = flow.createOut("out1", new Export("default", Cached.class));
-        FlowDescription desc = new IdentityFlow<Cached>(in, out);
+        FlowDescription desc = new IdentityFlow<>(in, out);
 
         JobflowInfo info = compile(flow, desc);
         assertThat(info, not(nullValue()));

--- a/thundergate-project/asakusa-thundergate-plugin/src/test/java/com/asakusafw/compiler/bulkloader/testing/model/Cached.java
+++ b/thundergate-project/asakusa-thundergate-plugin/src/test/java/com/asakusafw/compiler/bulkloader/testing/model/Cached.java
@@ -117,6 +117,9 @@ import com.asakusafw.vocabulary.bulkloader.PrimaryKey;
     @Override public long __tgc__SystemId() {
         return this.getSid();
     }
+    @Override public long __tgc__Timestamp() {
+        return this.getTimestamp().getElapsedSeconds();
+    }
     @Override public boolean __tgc__Deleted() {
         return false;
     }

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/CacheInfo.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/CacheInfo.java
@@ -137,7 +137,7 @@ public class CacheInfo {
         this.timestamp = (Calendar) timestamp.clone();
         this.timestamp.set(Calendar.MILLISECOND, 0);
         this.tableName = tableName;
-        this.columnNames = new TreeSet<String>(columnNames);
+        this.columnNames = new TreeSet<>(columnNames);
         this.modelClassName = modelClassName;
         this.modelClassVersion = modelClassVersion;
     }
@@ -276,7 +276,7 @@ public class CacheInfo {
 
     private static Set<String> split(String packed) {
         assert packed != null;
-        Set<String> results = new TreeSet<String>();
+        Set<String> results = new TreeSet<>();
         String[] entries = packed.split(COLUMN_SEPARATOR);
         Collections.addAll(results, entries);
         return results;

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/CacheStorage.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/CacheStorage.java
@@ -143,11 +143,8 @@ public class CacheStorage implements Closeable {
             return null;
         }
         Properties properties = new Properties();
-        FSDataInputStream in = fs.open(path);
-        try {
+        try (FSDataInputStream in = fs.open(path)) {
             properties.load(in);
-        } finally {
-            in.close();
         }
         try {
             return CacheInfo.loadFrom(properties);
@@ -189,13 +186,10 @@ public class CacheStorage implements Closeable {
         assert path != null;
         Properties properties = new Properties();
         info.storeTo(properties);
-        FSDataOutputStream out = fs.create(path);
-        try {
+        try (FSDataOutputStream out = fs.create(path)) {
             properties.store(out, MessageFormat.format(
                     "Cache for {0}",
                     info.getId()));
-        } finally {
-            out.close();
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/ThunderGateCacheSupport.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/ThunderGateCacheSupport.java
@@ -18,6 +18,7 @@ package com.asakusafw.thundergate.runtime.cache;
 /**
  * An interface for data models which supports ThunderGate cache features.
  * @since 0.2.3
+ * @version 0.8.1
  */
 public interface ThunderGateCacheSupport {
 
@@ -28,7 +29,7 @@ public interface ThunderGateCacheSupport {
     long __tgc__DataModelVersion();
 
     /**
-     * Returns the last updated timestamp colum name for this data model <em>class</em>.
+     * Returns the last updated timestamp column name for this data model <em>class</em>.
      * @return the last updated timestamp column name.
      */
     String __tgc__TimestampColumn();
@@ -39,6 +40,14 @@ public interface ThunderGateCacheSupport {
      * @throws RuntimeException if this data model does not have the system ID
      */
     long __tgc__SystemId();
+
+    /**
+     * Returns the timestamp of this data model object.
+     * @return the timestamp of this data model object
+     * @throws RuntimeException if this data model does not have the timestamp
+     * @since 0.8.1
+     */
+    long __tgc__Timestamp();
 
     /**
      * Returns whether this data model represents a deleted entry.

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/CacheBuildClient.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/CacheBuildClient.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
@@ -78,9 +79,11 @@ public class CacheBuildClient extends Configured implements Tool {
 
     private Class<?> modelClass;
 
+    private String tableName;
+
     @Override
     public int run(String[] args) throws Exception {
-        if (args.length != 3) {
+        if (args.length != 4) {
             throw new IllegalArgumentException(MessageFormat.format(
                     "Invalid arguments: {0}",
                     Arrays.toString(args)));
@@ -99,6 +102,7 @@ public class CacheBuildClient extends Configured implements Tool {
 
         Path cacheDirectory = new Path(args[1]);
         modelClass = getConf().getClassByName(args[2]);
+        tableName = args[3];
         this.storage = new CacheStorage(getConf(), cacheDirectory.toUri());
         try {
             clearNext();
@@ -121,8 +125,7 @@ public class CacheBuildClient extends Configured implements Tool {
     }
 
     private void update() throws IOException, InterruptedException {
-        Job job = JobCompatibility.newJob(getConf());
-        job.setJobName("TGC-UPDATE-" + storage.getPatchDirectory());
+        Job job = newJob();
 
         List<StageInput> inputList = new ArrayList<>();
         inputList.add(new StageInput(
@@ -188,9 +191,7 @@ public class CacheBuildClient extends Configured implements Tool {
     }
 
     private void create() throws InterruptedException, IOException {
-        Job job = JobCompatibility.newJob(getConf());
-        job.setJobName("TGC-CREATE-" + storage.getPatchDirectory());
-
+        Job job = newJob();
         List<StageInput> inputList = new ArrayList<>();
         inputList.add(new StageInput(
                 storage.getPatchContents("*").toString(),
@@ -244,6 +245,14 @@ public class CacheBuildClient extends Configured implements Tool {
                 getNextProperties(),
                 false,
                 storage.getConfiguration());
+    }
+
+    private Job newJob() throws IOException {
+        Job job = JobCompatibility.newJob(getConf());
+        job.setJobName("TGC-CREATE-" + tableName);
+        Configuration conf = job.getConfiguration();
+        Invalidation.setupInvalidationTimestamp(conf, tableName);
+        return job;
     }
 
     private void switchHead() throws IOException {

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/CacheBuildClient.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/CacheBuildClient.java
@@ -124,7 +124,7 @@ public class CacheBuildClient extends Configured implements Tool {
         Job job = JobCompatibility.newJob(getConf());
         job.setJobName("TGC-UPDATE-" + storage.getPatchDirectory());
 
-        List<StageInput> inputList = new ArrayList<StageInput>();
+        List<StageInput> inputList = new ArrayList<>();
         inputList.add(new StageInput(
                 storage.getHeadContents("*").toString(),
                 TemporaryInputFormat.class,
@@ -191,7 +191,7 @@ public class CacheBuildClient extends Configured implements Tool {
         Job job = JobCompatibility.newJob(getConf());
         job.setJobName("TGC-CREATE-" + storage.getPatchDirectory());
 
-        List<StageInput> inputList = new ArrayList<StageInput>();
+        List<StageInput> inputList = new ArrayList<>();
         inputList.add(new StageInput(
                 storage.getPatchContents("*").toString(),
                 TemporaryInputFormat.class,

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/DeleteMapper.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/DeleteMapper.java
@@ -30,12 +30,20 @@ public class DeleteMapper extends Mapper<
         NullWritable, ThunderGateCacheSupport,
         NullWritable, ThunderGateCacheSupport> {
 
+    private long invalidate;
+
+    @Override
+    protected void setup(Context context) throws IOException, InterruptedException {
+        super.setup(context);
+        this.invalidate = Invalidation.getInvalidationTimestamp(context.getConfiguration());
+    }
+
     @Override
     protected void map(
             NullWritable key,
             ThunderGateCacheSupport value,
             Context context) throws IOException, InterruptedException {
-        if (value.__tgc__Deleted() == false) {
+        if (value.__tgc__Deleted() == false && Invalidation.isStillValid(value, invalidate)) {
             context.write(key, value);
         }
     }

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/Invalidation.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/Invalidation.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.thundergate.runtime.cache.mapreduce;
+
+import java.text.MessageFormat;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+
+import com.asakusafw.runtime.value.DateUtil;
+import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
+
+/**
+ * Utilities about cache invalidation.
+ * @since 0.8.1
+ */
+public final class Invalidation {
+
+    static final Log LOG = LogFactory.getLog(Invalidation.class);
+
+    /**
+     * The Hadoop configuration key of invalidation target tables (in regular expression).
+     */
+    public static final String KEY_INVALIDATION_TARGET = "com.asakusafw.thundergate.cache.invalidate.tables";
+
+    /**
+     * The Hadoop configuration key of invalidation ending timestamp.
+     */
+    public static final String KEY_INVALIDATION_TIMESTAMP = "com.asakusafw.thundergate.cache.invalidate.until";
+
+    /**
+     * The format of timestamp value.
+     */
+    public static final String FORMAT_TIMESTAMP = "yyyy-MM-dd HH:mm:ss";
+
+    private static final String KEY_INTERNAL_TIMESTAMP = "com.asakusafw.thundergate.cache.invalidate.timestamp";
+
+    private Invalidation() {
+        return;
+    }
+
+    /**
+     * Initializes invalidation timestamp.
+     * @param configuration the target configuration
+     * @param tableName the target table name
+     */
+    public static void setupInvalidationTimestamp(Configuration configuration, String tableName) {
+        long timestamp = getTimestamp(configuration);
+        if (timestamp > 0L && isTarget(configuration, tableName)) {
+            LOG.info(MessageFormat.format(
+                    "enabling ThunderGate cache invalidation: {0} until {1}",
+                    tableName, configuration.get(KEY_INVALIDATION_TIMESTAMP)));
+            configuration.setLong(KEY_INTERNAL_TIMESTAMP, timestamp);
+        }
+    }
+
+    private static long getTimestamp(Configuration conf) {
+        String until = conf.get(KEY_INVALIDATION_TIMESTAMP);
+        if (until == null) {
+            LOG.debug(MessageFormat.format(
+                    "invalidation timstamp is not set: {0}",
+                    KEY_INVALIDATION_TIMESTAMP));
+            return 0L;
+        }
+        LOG.debug(MessageFormat.format(
+                "invalidation timstamp: {0}={1}",
+                KEY_INVALIDATION_TIMESTAMP, until));
+        long timestamp = DateUtil.parseDateTime(until, '-', ' ', ':');
+        if (timestamp < 0) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "invalid timestamp: {0}={1}",
+                    KEY_INVALIDATION_TIMESTAMP, until));
+        }
+        return timestamp;
+    }
+
+    private static boolean isTarget(Configuration conf, String table) {
+        String pattern = conf.get(KEY_INVALIDATION_TARGET);
+        if (pattern == null) {
+            LOG.debug(MessageFormat.format(
+                    "invalidation target is not set: {0}",
+                    KEY_INVALIDATION_TARGET));
+            return false;
+        }
+        try {
+            boolean matched = Pattern.compile(pattern).matcher(table).matches();
+            LOG.debug(MessageFormat.format(
+                    "invalidation target matching: {0}=\"{1}\" / \"{2}\" => {3}",
+                    KEY_INVALIDATION_TARGET, pattern, table, matched));
+            return matched;
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "invalid table name pattern: {0}={1}",
+                    KEY_INVALIDATION_TARGET, pattern));
+        }
+    }
+
+    /**
+     * Returns the ending timestamp of each record is invalidate.
+     * @param configuration the current configuration
+     * @return the timestamp - each record is invalidated only if it is older than the timestamp,
+     *     may be {@code 0} if invalidation is not enabled
+     */
+    public static long getInvalidationTimestamp(Configuration configuration) {
+        return configuration.getLong(KEY_INTERNAL_TIMESTAMP, 0);
+    }
+
+    /**
+     * Returns whether the target record is still valid or not.
+     * @param model the target record
+     * @param invalidation the invalidation timestamp
+     * @return {@code true} if it is still valid, otherwise {@code false}
+     */
+    public static boolean isStillValid(ThunderGateCacheSupport model, long invalidation) {
+        return model.__tgc__Timestamp() >= invalidation;
+    }
+}

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/PatchApplyKey.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/PatchApplyKey.java
@@ -193,7 +193,6 @@ public class PatchApplyKey implements WritableComparable<PatchApplyKey> {
      * Group comparator for {@link PatchApplyKey}.
      * @since 0.2.3
      */
-    @SuppressWarnings("rawtypes")
     public static final class GroupComparator extends WritableComparator implements Externalizable {
 
         /**

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/property/PropertyLoader.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/property/PropertyLoader.java
@@ -190,11 +190,8 @@ public class PropertyLoader implements Closeable {
     private Properties loadProperties(String path) throws IOException {
         assert path != null;
         Properties result = new Properties();
-        InputStream input = open(path);
-        try {
+        try (InputStream input = open(path)) {
             result.load(input);
-        } finally {
-            input.close();
         }
         return result;
     }

--- a/thundergate-project/asakusa-thundergate-runtime/src/test/java/com/asakusafw/thundergate/runtime/cache/CacheStorageTest.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/test/java/com/asakusafw/thundergate/runtime/cache/CacheStorageTest.java
@@ -54,17 +54,13 @@ public class CacheStorageTest {
     public void deleteHead() throws Exception {
         File dir = folder.newFolder("testing");
         dir.delete();
-        CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI());
-        try {
+        try (CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI())) {
             Path content = storage.getHeadContents("a");
-            FSDataOutputStream output = storage.getFileSystem().create(content);
-            try {
+            try (FSDataOutputStream output = storage.getFileSystem().create(content)) {
                 IOUtils.copyBytes(
                         new ByteArrayInputStream("Hello, world".getBytes()),
                         output,
                         storage.getConfiguration());
-            } finally {
-                output.close();
             }
 
             assertThat(storage.getFileSystem().exists(storage.getHeadDirectory()), is(true));
@@ -72,8 +68,6 @@ public class CacheStorageTest {
 
             storage.deleteHead();
             assertThat(storage.getFileSystem().exists(storage.getHeadDirectory()), is(false));
-        } finally {
-            storage.close();
         }
     }
 
@@ -85,17 +79,13 @@ public class CacheStorageTest {
     public void deletePatch() throws Exception {
         File dir = folder.newFolder("testing");
         dir.delete();
-        CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI());
-        try {
+        try (CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI())) {
             Path content = storage.getPatchContents("a");
-            FSDataOutputStream output = storage.getFileSystem().create(content);
-            try {
+            try (FSDataOutputStream output = storage.getFileSystem().create(content)) {
                 IOUtils.copyBytes(
                         new ByteArrayInputStream("Hello, world".getBytes()),
                         output,
                         storage.getConfiguration());
-            } finally {
-                output.close();
             }
 
             assertThat(storage.getFileSystem().exists(storage.getPatchDirectory()), is(true));
@@ -103,8 +93,6 @@ public class CacheStorageTest {
 
             storage.deletePatch();
             assertThat(storage.getFileSystem().exists(storage.getPatchDirectory()), is(false));
-        } finally {
-            storage.close();
         }
     }
 
@@ -116,27 +104,20 @@ public class CacheStorageTest {
     public void deleteAll() throws Exception {
         File dir = folder.newFolder("testing");
         dir.delete();
-        CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI());
-        try {
+        try (CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI())) {
             Path headContent = storage.getHeadContents("a");
-            FSDataOutputStream headOutput = storage.getFileSystem().create(headContent);
-            try {
+            try (FSDataOutputStream output = storage.getFileSystem().create(headContent)) {
                 IOUtils.copyBytes(
                         new ByteArrayInputStream("Hello, world".getBytes()),
-                        headOutput,
+                        output,
                         storage.getConfiguration());
-            } finally {
-                headOutput.close();
             }
             Path patchContent = storage.getPatchContents("a");
-            FSDataOutputStream patchOutput = storage.getFileSystem().create(patchContent);
-            try {
+            try (FSDataOutputStream output = storage.getFileSystem().create(patchContent)) {
                 IOUtils.copyBytes(
                         new ByteArrayInputStream("Hello, world".getBytes()),
-                        patchOutput,
+                        output,
                         storage.getConfiguration());
-            } finally {
-                patchOutput.close();
             }
 
             assertThat(storage.getFileSystem().exists(storage.getHeadDirectory()), is(true));
@@ -145,8 +126,6 @@ public class CacheStorageTest {
             assertThat(storage.deleteAll(), is(true));
             assertThat(storage.getFileSystem().exists(storage.getHeadDirectory()), is(false));
             assertThat(storage.getFileSystem().exists(storage.getPatchDirectory()), is(false));
-        } finally {
-            storage.close();
         }
     }
 
@@ -158,11 +137,8 @@ public class CacheStorageTest {
     public void deleteAll_missing() throws Exception {
         File dir = folder.newFolder("testing");
         Assume.assumeTrue(dir.delete());
-        CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI());
-        try {
+        try (CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI())) {
             assertThat(storage.deleteAll(), is(false));
-        } finally {
-            storage.close();
         }
     }
 
@@ -182,8 +158,7 @@ public class CacheStorageTest {
                 123L);
         File dir = folder.newFolder("testing");
         dir.delete();
-        CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI());
-        try {
+        try (CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI())) {
             storage.putPatchCacheInfo(info);
 
             assertThat(storage.getFileSystem().exists(storage.getPatchDirectory()), is(true));
@@ -197,8 +172,6 @@ public class CacheStorageTest {
             assertThat(restored.getColumnNames(), is(info.getColumnNames()));
             assertThat(restored.getModelClassName(), is(info.getModelClassName()));
             assertThat(restored.getModelClassVersion(), is(info.getModelClassVersion()));
-        } finally {
-            storage.close();
         }
     }
 
@@ -218,8 +191,7 @@ public class CacheStorageTest {
                 123L);
         File dir = folder.newFolder("testing");
         dir.delete();
-        CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI());
-        try {
+        try (CacheStorage storage = new CacheStorage(new Configuration(), dir.toURI())) {
             storage.putHeadCacheInfo(info);
 
             assertThat(storage.getFileSystem().exists(storage.getPatchDirectory()), is(false));
@@ -233,8 +205,6 @@ public class CacheStorageTest {
             assertThat(restored.getColumnNames(), is(info.getColumnNames()));
             assertThat(restored.getModelClassName(), is(info.getModelClassName()));
             assertThat(restored.getModelClassVersion(), is(info.getModelClassVersion()));
-        } finally {
-            storage.close();
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-runtime/src/test/java/com/asakusafw/thundergate/runtime/property/PropertyLoaderTest.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/test/java/com/asakusafw/thundergate/runtime/property/PropertyLoaderTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Properties;
 import java.util.zip.ZipOutputStream;
 
@@ -65,28 +64,19 @@ public class PropertyLoaderTest {
         Properties source = new Properties();
         source.setProperty("hello", "world");
 
-        OutputStream out = new FileOutputStream(zip);
-        try {
-            ZipOutputStream archive = new ZipOutputStream(out);
+        try (ZipOutputStream archive = new ZipOutputStream(new FileOutputStream(zip))) {
             PropertyLoader.saveImporterProperties(archive, "default", source);
-            archive.close();
-        } finally {
-            out.close();
         }
 
-        PropertyLoader loader = new PropertyLoader(zip, "default");
-        try {
+        try (PropertyLoader loader = new PropertyLoader(zip, "default")) {
             Properties importer = loader.loadImporterProperties();
             assertThat(importer, is(source));
-
             try {
                 loader.loadExporterProperties();
                 fail();
             } catch (IOException e) {
                 // ok.
             }
-        } finally {
-            loader.close();
         }
     }
 
@@ -99,28 +89,19 @@ public class PropertyLoaderTest {
         Properties source = new Properties();
         source.setProperty("hello", "world");
 
-        OutputStream out = new FileOutputStream(zip);
-        try {
-            ZipOutputStream archive = new ZipOutputStream(out);
+        try (ZipOutputStream archive = new ZipOutputStream(new FileOutputStream(zip))){
             PropertyLoader.saveExporterProperties(archive, "default", source);
-            archive.close();
-        } finally {
-            out.close();
         }
 
-        PropertyLoader loader = new PropertyLoader(zip, "default");
-        try {
+        try (PropertyLoader loader = new PropertyLoader(zip, "default")) {
             Properties exporter = loader.loadExporterProperties();
             assertThat(exporter, is(source));
-
             try {
                 loader.loadImporterProperties();
                 fail();
             } catch (IOException e) {
                 // ok.
             }
-        } finally {
-            loader.close();
         }
     }
 }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/BulkLoadExporterRetriever.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/BulkLoadExporterRetriever.java
@@ -67,7 +67,7 @@ public class BulkLoadExporterRetriever extends AbstractExporterRetriever<BulkLoa
         Connection conn = conf.open();
         boolean green = false;
         try {
-            ModelOutput<V> output = new TableOutput<V>(info, conn);
+            ModelOutput<V> output = new TableOutput<>(info, conn);
             green = true;
             return output;
         } finally {
@@ -91,7 +91,7 @@ public class BulkLoadExporterRetriever extends AbstractExporterRetriever<BulkLoa
         Connection conn = conf.open();
         boolean green = false;
         try {
-            DataModelSource source = new TableSource<V>(info, conn);
+            DataModelSource source = new TableSource<>(info, conn);
             green = true;
             return source;
         } finally {
@@ -111,7 +111,7 @@ public class BulkLoadExporterRetriever extends AbstractExporterRetriever<BulkLoa
         assert definition != null;
         assert description != null;
         if (isNormalTarget(definition, description)) {
-            return new TableInfo<V>(
+            return new TableInfo<>(
                     definition,
                     description.getTableName(),
                     description.getTargetColumnNames());
@@ -120,10 +120,10 @@ public class BulkLoadExporterRetriever extends AbstractExporterRetriever<BulkLoa
             List<String> columns = dup.getColumnNames();
             if (columns.contains(dup.getErrorCodeColumnName()) == false) {
                 // restore error code column name
-                columns = new ArrayList<String>(columns);
+                columns = new ArrayList<>(columns);
                 columns.add(dup.getErrorCodeColumnName());
             }
-            return new TableInfo<V>(
+            return new TableInfo<>(
                     definition,
                     dup.getTableName(),
                     columns);

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/BulkLoadImporterPreparator.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/BulkLoadImporterPreparator.java
@@ -64,7 +64,7 @@ public class BulkLoadImporterPreparator extends AbstractImporterPreparator<BulkL
         Connection conn = conf.open();
         boolean green = false;
         try {
-            ModelOutput<V> output = new TableOutput<V>(info, conn);
+            ModelOutput<V> output = new TableOutput<>(info, conn);
             green = true;
             return output;
         } finally {
@@ -83,7 +83,7 @@ public class BulkLoadImporterPreparator extends AbstractImporterPreparator<BulkL
             BulkLoadImporterDescription description) {
         assert definition != null;
         assert description != null;
-        return new TableInfo<V>(
+        return new TableInfo<>(
                 definition,
                 description.getTableName(),
                 description.getColumnNames(),

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/Configuration.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/Configuration.java
@@ -258,13 +258,10 @@ public class Configuration {
 
     private static Properties loadProperties(URL resource) throws IOException {
         assert resource != null;
-        InputStream in = resource.openStream();
-        try {
+        try (InputStream in = resource.openStream()) {
             Properties p = new Properties();
             p.load(in);
             return p;
-        } finally {
-            in.close();
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableInfo.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableInfo.java
@@ -168,7 +168,7 @@ public class TableInfo<T> {
         assert definition != null;
         assert columnNames != null;
         Map<String, PropertyName> allMapping = extractAllMappings();
-        Map<String, PropertyName> results = new LinkedHashMap<String, PropertyName>();
+        Map<String, PropertyName> results = new LinkedHashMap<>();
         for (String column : columnNames) {
             PropertyName propertyName = allMapping.get(column);
             if (propertyName == null) {
@@ -186,7 +186,7 @@ public class TableInfo<T> {
 
     private Map<String, PropertyName> extractAllMappings() {
         assert definition != null;
-        Map<String, PropertyName> results = new TreeMap<String, PropertyName>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, PropertyName> results = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (PropertyName name : definition.getProperties()) {
             PropertyType type = definition.getType(name);
             assert type != null;

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableOutput.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableOutput.java
@@ -120,7 +120,7 @@ public class TableOutput<T> implements ModelOutput<T> {
             LOG.debug("Building insert statement: {}", table);
 
             String timestamp = table.getTimestampColumn();
-            List<String> columns = new ArrayList<String>(table.getColumnsToProperties().keySet());
+            List<String> columns = new ArrayList<>(table.getColumnsToProperties().keySet());
             if (timestamp != null) {
                 columns.remove(timestamp);
                 columns.add(timestamp);

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableSourceProvider.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableSourceProvider.java
@@ -67,12 +67,12 @@ public class TableSourceProvider implements DataModelSourceProvider {
             conn = conf.open();
             DatabaseMetaData meta = conn.getMetaData();
             res = meta.getColumns(null, null, tableName, "%");
-            List<String> columnList = new ArrayList<String>();
+            List<String> columnList = new ArrayList<>();
             while (res.next()) {
                 columnList.add(res.getString("COLUMN_NAME"));
             }
-            TableInfo<T> table = new TableInfo<T>(definition, tableName, columnList);
-            return new TableSource<T>(table, conn);
+            TableInfo<T> table = new TableInfo<>(definition, tableName, columnList);
+            return new TableSource<>(table, conn);
         } catch (SQLException e) {
             throw new IOException(e);
         }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/BulkLoadImporterPreparatorTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/BulkLoadImporterPreparatorTest.java
@@ -36,7 +36,7 @@ import com.asakusafw.vocabulary.bulkloader.DbImporterDescription;
  */
 public class BulkLoadImporterPreparatorTest {
 
-    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<Simple>(Simple.class);
+    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<>(Simple.class);
 
     static final DbImporterDescription NORMAL = new DbImporterDescription() {
         @Override
@@ -214,14 +214,11 @@ public class BulkLoadImporterPreparatorTest {
     public void output() throws IOException {
         context.put("importer", "importer");
         BulkLoadImporterPreparator prep = new BulkLoadImporterPreparator();
-        ModelOutput<Simple> output = prep.createOutput(SIMPLE, NORMAL);
-        try {
+        try (ModelOutput<Simple> output = prep.createOutput(SIMPLE, NORMAL)) {
             Simple simple = new Simple();
             simple.number = 100;
             simple.text = "Hello, world!";
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -237,18 +234,14 @@ public class BulkLoadImporterPreparatorTest {
     public void output_missing() throws IOException {
         context.put("importer", "importer");
         BulkLoadImporterPreparator prep = new BulkLoadImporterPreparator();
-        ModelOutput<Simple> output = prep.createOutput(SIMPLE, MISSING);
-        output.close();
+        try (ModelOutput<Simple> output = prep.createOutput(SIMPLE, MISSING)) {
+            // nothing to do
+        }
     }
 
     private void insert(Simple simple) {
-        try {
-            TableOutput<Simple> output = new TableOutput<Simple>(all(), h2.open());
-            try {
-                output.write(simple);
-            } finally {
-                output.close();
-            }
+        try (TableOutput<Simple> output = new TableOutput<>(all(), h2.open())) {
+            output.write(simple);
         } catch (Exception e) {
             throw new AssertionError(e);
         }
@@ -272,6 +265,6 @@ public class BulkLoadImporterPreparatorTest {
     }
 
     private TableInfo<Simple> info(String... columns) {
-        return new TableInfo<Simple>(SIMPLE, "SIMPLE", Arrays.asList(columns));
+        return new TableInfo<>(SIMPLE, "SIMPLE", Arrays.asList(columns));
     }
 }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/CacheSupport.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/CacheSupport.java
@@ -82,6 +82,11 @@ public class CacheSupport implements ThunderGateCacheSupport {
     }
 
     @Override
+    public long __tgc__Timestamp() {
+        return datetimeValue.getTimeInMillis();
+    }
+
+    @Override
     public String __tgc__TimestampColumn() {
         return "C_DATETIME";
     }
@@ -150,6 +155,6 @@ public class CacheSupport implements ThunderGateCacheSupport {
 
     @Override
     public String toString() {
-        return new SimpleDataModelDefinition<CacheSupport>(CacheSupport.class).toReflection(this).toString();
+        return new SimpleDataModelDefinition<>(CacheSupport.class).toReflection(this).toString();
     }
 }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/ConfigurationContext.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/ConfigurationContext.java
@@ -96,11 +96,8 @@ public class ConfigurationContext extends ExternalResource {
             } else {
                 file = folder.newFile(MessageFormat.format(Configuration.FILE_PATTERN, targetName));
             }
-            FileOutputStream out = new FileOutputStream(file);
-            try {
+            try (FileOutputStream out = new FileOutputStream(file)) {
                 properties.store(out, "testing");
-            } finally {
-                out.close();
             }
         } catch (IOException e) {
             throw new AssertionError(e);

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/ConfigurationTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/ConfigurationTest.java
@@ -77,12 +77,9 @@ public class ConfigurationTest {
     public void target() throws Exception {
         context.put("config", "config");
         Configuration conf = Configuration.load("config");
-        Connection conn = conf.open();
-        try {
+        try (Connection conn = conf.open()) {
             conn.createStatement().execute("INSERT INTO TESTING (NUMBER, TEXT) VALUES(1, 'a')");
             conn.commit();
-        } finally {
-            conn.close();
         }
         assertThat(h2.count("TESTING"), is(1));
     }
@@ -95,12 +92,9 @@ public class ConfigurationTest {
     public void common() throws Exception {
         context.put(null, "config");
         Configuration conf = Configuration.load("config");
-        Connection conn = conf.open();
-        try {
+        try (Connection conn = conf.open()) {
             conn.createStatement().execute("INSERT INTO TESTING (NUMBER, TEXT) VALUES(1, 'a')");
             conn.commit();
-        } finally {
-            conn.close();
         }
         assertThat(h2.count("TESTING"), is(1));
     }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/DupCheck.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/DupCheck.java
@@ -250,6 +250,6 @@ public class DupCheck {
 
     @Override
     public String toString() {
-        return new SimpleDataModelDefinition<DupCheck>(DupCheck.class).toReflection(this).toString();
+        return new SimpleDataModelDefinition<>(DupCheck.class).toReflection(this).toString();
     }
 }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2Resource.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2Resource.java
@@ -18,7 +18,6 @@ package com.asakusafw.testdriver.bulkloader;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -155,7 +154,7 @@ public class H2Resource extends TestWatcher {
             ResultSet rs = s.executeQuery(sql);
             ResultSetMetaData meta = rs.getMetaData();
             int size = meta.getColumnCount();
-            List<List<Object>> results = new ArrayList<List<Object>>();
+            List<List<Object>> results = new ArrayList<>();
             while (rs.next()) {
                 Object[] columns = new Object[size];
                 for (int i = 0; i < size; i++) {
@@ -182,12 +181,9 @@ public class H2Resource extends TestWatcher {
     }
 
     private void execute0(String sql) throws SQLException {
-        PreparedStatement ps = connection.prepareStatement(sql);
-        try {
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.execute();
             connection.commit();
-        } finally {
-            ps.close();
         }
     }
 
@@ -201,9 +197,8 @@ public class H2Resource extends TestWatcher {
     }
 
     private String load(String resource) {
-        InputStream source = context.getResourceAsStream(resource);
-        assertThat(resource, source, is(not(nullValue())));
-        try {
+        try (InputStream source = context.getResourceAsStream(resource)) {
+            assertThat(resource, source, is(not(nullValue())));
             StringBuilder buf = new StringBuilder();
             Reader reader = new InputStreamReader(source, "UTF-8");
             char[] cbuf = new char[1024];
@@ -217,12 +212,6 @@ public class H2Resource extends TestWatcher {
             return buf.toString();
         } catch (Exception e) {
             throw new AssertionError(e);
-        } finally {
-            try {
-                source.close();
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2ResourceTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2ResourceTest.java
@@ -71,20 +71,13 @@ public class H2ResourceTest {
     public void execute_direct() throws Exception {
         h2.execute("INSERT INTO TESTING (NUMBER, TEXT) VALUES(100, 'Hello, world!')");
 
-        Connection conn = DriverManager.getConnection("jdbc:h2:mem:test");
-        try {
-            Statement stmt = conn.createStatement();
-            try {
-                ResultSet rs = stmt.executeQuery("SELECT NUMBER, TEXT FROM TESTING");
-                assertThat(rs.next(), is(true));
-                assertThat(rs.getObject(1), is((Object) 100));
-                assertThat(rs.getObject(2), is((Object) "Hello, world!"));
-                assertThat(rs.next(), is(false));
-            } finally {
-                stmt.close();
-            }
-        } finally {
-            conn.close();
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test");
+                Statement stmt = conn.createStatement()) {
+            ResultSet rs = stmt.executeQuery("SELECT NUMBER, TEXT FROM TESTING");
+            assertThat(rs.next(), is(true));
+            assertThat(rs.getObject(1), is((Object) 100));
+            assertThat(rs.getObject(2), is((Object) "Hello, world!"));
+            assertThat(rs.next(), is(false));
         }
     }
 }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/Simple.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/Simple.java
@@ -250,6 +250,6 @@ public class Simple {
 
     @Override
     public String toString() {
-        return new SimpleDataModelDefinition<Simple>(Simple.class).toReflection(this).toString();
+        return new SimpleDataModelDefinition<>(Simple.class).toReflection(this).toString();
     }
 }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableInfoTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableInfoTest.java
@@ -38,16 +38,16 @@ import com.asakusafw.testdriver.model.SimpleDataModelDefinition;
  */
 public class TableInfoTest {
 
-    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<Simple>(Simple.class);
+    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<>(Simple.class);
 
-    static final DataModelDefinition<CacheSupport> CACHE = new SimpleDataModelDefinition<CacheSupport>(CacheSupport.class);
+    static final DataModelDefinition<CacheSupport> CACHE = new SimpleDataModelDefinition<>(CacheSupport.class);
 
     /**
      * simple.
      */
     @Test
     public void simple() {
-        TableInfo<Simple> info = new TableInfo<Simple>(SIMPLE, "SMPL", Arrays.asList(new String[] {
+        TableInfo<Simple> info = new TableInfo<>(SIMPLE, "SMPL", Arrays.asList(new String[] {
                 "NUMBER"
         }));
         assertThat(info.getDefinition(), is(SIMPLE));
@@ -63,7 +63,7 @@ public class TableInfoTest {
      */
     @Test
     public void ordered() {
-        TableInfo<Simple> info = new TableInfo<Simple>(SIMPLE, "SMPL", Arrays.asList(new String[] {
+        TableInfo<Simple> info = new TableInfo<>(SIMPLE, "SMPL", Arrays.asList(new String[] {
                 "C_BYTE",
                 "C_SHORT",
                 "C_FLOAT",
@@ -77,7 +77,7 @@ public class TableInfoTest {
         assertThat(map.get("C_SHORT"), is(name("short_value")));
         assertThat(map.get("C_FLOAT"), is(name("float_value")));
         assertThat(map.get("C_DOUBLE"), is(name("double_value")));
-        List<String> names =  new ArrayList<String>(map.keySet());
+        List<String> names =  new ArrayList<>(map.keySet());
         assertThat(names, is(Arrays.asList("C_BYTE", "C_SHORT", "C_FLOAT", "C_DOUBLE")));
     }
 
@@ -86,7 +86,7 @@ public class TableInfoTest {
      */
     @Test
     public void infer() {
-        TableInfo<Simple> info = new TableInfo<Simple>(SIMPLE, "SMPL", Arrays.asList(new String[] {
+        TableInfo<Simple> info = new TableInfo<>(SIMPLE, "SMPL", Arrays.asList(new String[] {
                 "INFER_ORIGINAL_NAME"
         }));
         assertThat(info.getDefinition(), is(SIMPLE));
@@ -101,7 +101,7 @@ public class TableInfoTest {
      */
     @Test
     public void skip() {
-        TableInfo<Simple> info = new TableInfo<Simple>(SIMPLE, "SMPL", Arrays.asList(new String[] {
+        TableInfo<Simple> info = new TableInfo<>(SIMPLE, "SMPL", Arrays.asList(new String[] {
                 "C_INTEGER"
         }));
         assertThat(info.getDefinition(), is(SIMPLE));
@@ -115,7 +115,7 @@ public class TableInfoTest {
      */
     @Test
     public void unknown() {
-        TableInfo<Simple> info = new TableInfo<Simple>(SIMPLE, "SMPL", Arrays.asList(new String[] {
+        TableInfo<Simple> info = new TableInfo<>(SIMPLE, "SMPL", Arrays.asList(new String[] {
                 "UNKNOWN_COLUMN"
         }));
         assertThat(info.getDefinition(), is(SIMPLE));
@@ -129,7 +129,7 @@ public class TableInfoTest {
      */
     @Test
     public void timestamp() {
-        TableInfo<CacheSupport> info = new TableInfo<CacheSupport>(CACHE, "SMPL", Arrays.asList(new String[] {
+        TableInfo<CacheSupport> info = new TableInfo<>(CACHE, "SMPL", Arrays.asList(new String[] {
                 "NUMBER"
         }));
         assertThat(info.getTimestampColumn(), is("C_DATETIME"));

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableOutputTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableOutputTest.java
@@ -39,9 +39,9 @@ import com.asakusafw.testdriver.model.SimpleDataModelDefinition;
  */
 public class TableOutputTest {
 
-    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<Simple>(Simple.class);
+    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<>(Simple.class);
 
-    static final DataModelDefinition<CacheSupport> CACHE = new SimpleDataModelDefinition<CacheSupport>(CacheSupport.class);
+    static final DataModelDefinition<CacheSupport> CACHE = new SimpleDataModelDefinition<>(CacheSupport.class);
 
     /**
      * H2 database.
@@ -60,9 +60,9 @@ public class TableOutputTest {
      */
     @Test
     public void empty() throws Exception {
-        TableOutput<Simple> output = new TableOutput<Simple>(info("NUMBER", "TEXT"), h2.open());
-        output.close();
-
+        try (TableOutput<Simple> output = new TableOutput<>(info("NUMBER", "TEXT"), h2.open())) {
+            // do nothing
+        }
         assertThat(h2.count("SIMPLE"), is(0));
     }
 
@@ -72,14 +72,11 @@ public class TableOutputTest {
      */
     @Test
     public void single() throws Exception {
-        TableOutput<Simple> output = new TableOutput<Simple>(info("NUMBER", "TEXT"), h2.open());
-        try {
+        try (TableOutput<Simple> output = new TableOutput<>(info("NUMBER", "TEXT"), h2.open())) {
             Simple simple = new Simple();
             simple.number = 100;
             simple.text = "Hello, world!";
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -94,8 +91,7 @@ public class TableOutputTest {
      */
     @Test
     public void multiple() throws Exception {
-        TableOutput<Simple> output = new TableOutput<Simple>(info("NUMBER", "TEXT"), h2.open());
-        try {
+        try (TableOutput<Simple> output = new TableOutput<>(info("NUMBER", "TEXT"), h2.open())) {
             Simple simple = new Simple();
             simple.number = 100;
             simple.text = "aaa";
@@ -108,8 +104,6 @@ public class TableOutputTest {
             simple.number = 300;
             simple.text = "ccc";
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(3));
@@ -151,7 +145,7 @@ public class TableOutputTest {
         simple.datetimeValue.clear();
         simple.datetimeValue.set(2000, 0, 2, 3, 4, 5);
 
-        TableOutput<Simple> output = new TableOutput<Simple>(info(
+        try (TableOutput<Simple> output = new TableOutput<>(info(
                 "NUMBER",
                 "TEXT",
                 "C_BOOL",
@@ -164,11 +158,8 @@ public class TableOutputTest {
                 "C_DATE",
                 "C_TIME",
                 "C_DATETIME"
-                ), h2.open());
-        try {
+                ), h2.open())) {
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -198,7 +189,7 @@ public class TableOutputTest {
         Simple simple = new Simple();
         simple.number = 100;
 
-        TableOutput<Simple> output = new TableOutput<Simple>(info(
+        try (TableOutput<Simple> output = new TableOutput<>(info(
                 "NUMBER",
                 "TEXT",
                 "C_BOOL",
@@ -211,11 +202,8 @@ public class TableOutputTest {
                 "C_DATE",
                 "C_TIME",
                 "C_DATETIME"
-                ), h2.open());
-        try {
+                ), h2.open())) {
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -234,16 +222,13 @@ public class TableOutputTest {
      */
     @Test
     public void timestamp() throws Exception {
-        TableOutput<CacheSupport> output = new TableOutput<CacheSupport>(
-                new TableInfo<CacheSupport>(CACHE, "SIMPLE", Arrays.asList("NUMBER", "TEXT")),
-                h2.open());
-        try {
+        try (TableOutput<CacheSupport> output = new TableOutput<>(
+                new TableInfo<>(CACHE, "SIMPLE", Arrays.asList("NUMBER", "TEXT")),
+                h2.open())) {
             CacheSupport simple = new CacheSupport();
             simple.number = 100;
             simple.text = "Hello, world!";
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -258,18 +243,15 @@ public class TableOutputTest {
      */
     @Test
     public void timestamp_overwrite() throws Exception {
-        TableOutput<CacheSupport> output = new TableOutput<CacheSupport>(
-                new TableInfo<CacheSupport>(CACHE, "SIMPLE", Arrays.asList("NUMBER", "TEXT", "C_DATETIME")),
-                h2.open());
-        try {
+        try (TableOutput<CacheSupport> output = new TableOutput<>(
+                new TableInfo<>(CACHE, "SIMPLE", Arrays.asList("NUMBER", "TEXT", "C_DATETIME")),
+                h2.open())) {
             CacheSupport simple = new CacheSupport();
             simple.number = 100;
             simple.text = "Hello, world!";
             simple.datetimeValue = Calendar.getInstance();
             simple.datetimeValue.setTimeInMillis(1);
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -286,18 +268,15 @@ public class TableOutputTest {
      */
     @Test
     public void timestamp_suppress_overwrite() throws Exception {
-        TableOutput<CacheSupport> output = new TableOutput<CacheSupport>(
-                new TableInfo<CacheSupport>(CACHE, "SIMPLE", Arrays.asList("NUMBER", "TEXT", "C_DATETIME"), false),
-                h2.open());
-        try {
+        try (TableOutput<CacheSupport> output = new TableOutput<>(
+                new TableInfo<>(CACHE, "SIMPLE", Arrays.asList("NUMBER", "TEXT", "C_DATETIME"), false),
+                h2.open())) {
             CacheSupport simple = new CacheSupport();
             simple.number = 100;
             simple.text = "Hello, world!";
             simple.datetimeValue = Calendar.getInstance();
             simple.datetimeValue.setTimeInMillis(1);
             output.write(simple);
-        } finally {
-            output.close();
         }
 
         assertThat(h2.count("SIMPLE"), is(1));
@@ -314,9 +293,10 @@ public class TableOutputTest {
      */
     @Test
     public void reclose() throws Exception {
-        TableOutput<Simple> output = new TableOutput<Simple>(info("NUMBER", "TEXT"), h2.open());
-        output.close();
-        output.close();
+        try (TableOutput<Simple> output = new TableOutput<>(info("NUMBER", "TEXT"), h2.open())) {
+            output.close();
+            output.close();
+        }
     }
 
     /**
@@ -326,19 +306,11 @@ public class TableOutputTest {
     @Test(expected = IOException.class)
     public void dropCtor() throws Exception {
         h2.execute("DROP TABLE SIMPLE");
-        Connection conn = h2.open();
-        try {
-            TableOutput<Simple> output = new TableOutput<Simple>(info("NUMBER", "TEXT"), conn);
-            try {
-                Simple simple = new Simple();
-                simple.number = 100;
-                output.write(simple);
-            } finally {
-                output.close();
-            }
-
-        } finally {
-            conn.close();
+        try (Connection conn = h2.open();
+                TableOutput<Simple> output = new TableOutput<>(info("NUMBER", "TEXT"), conn)) {
+            Simple simple = new Simple();
+            simple.number = 100;
+            output.write(simple);
         }
     }
 
@@ -348,28 +320,21 @@ public class TableOutputTest {
      */
     @Test(expected = IOException.class)
     public void dropWrite() throws Exception {
-        Connection conn = h2.open();
-        try {
-            TableOutput<Simple> output = new TableOutput<Simple>(info("NUMBER", "TEXT"), conn);
-            try {
-                h2.execute("DROP TABLE SIMPLE");
-                Simple simple = new Simple();
-                simple.number = 100;
-                output.write(simple);
-            } finally {
-                output.close();
-            }
-        } finally {
-            conn.close();
+        try (Connection conn = h2.open();
+                TableOutput<Simple> output = new TableOutput<>(info("NUMBER", "TEXT"), conn)) {
+            h2.execute("DROP TABLE SIMPLE");
+            Simple simple = new Simple();
+            simple.number = 100;
+            output.write(simple);
         }
     }
 
     private TableInfo<Simple> info(String... columns) {
-        return new TableInfo<Simple>(SIMPLE, "SIMPLE", Arrays.asList(columns));
+        return new TableInfo<>(SIMPLE, "SIMPLE", Arrays.asList(columns));
     }
 
     private List<List<Object>> table(Object[]... rows) {
-        List<List<Object>> results = new ArrayList<List<Object>>();
+        List<List<Object>> results = new ArrayList<>();
         for (Object[] row : rows) {
             results.add(Arrays.asList(row));
         }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableSourceProviderTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableSourceProviderTest.java
@@ -37,7 +37,7 @@ import com.asakusafw.testdriver.model.SimpleDataModelDefinition;
  */
 public class TableSourceProviderTest {
 
-    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<Simple>(Simple.class);
+    static final DataModelDefinition<Simple> SIMPLE = new SimpleDataModelDefinition<>(Simple.class);
 
     /**
      * H2 database.
@@ -72,13 +72,12 @@ public class TableSourceProviderTest {
         insert(simple, SIMPLE, "SIMPLE");
 
         TableSourceProvider provider = new TableSourceProvider();
-        DataModelSource source = provider.open(SIMPLE, new URI("bulkloader:provider:SIMPLE"), new TestContext.Empty());
-
-        try {
+        try (DataModelSource source = provider.open(
+                SIMPLE,
+                new URI("bulkloader:provider:SIMPLE"),
+                new TestContext.Empty())) {
             assertThat(next(source), is(simple));
             assertThat(next(source), is(nullValue()));
-        } finally {
-            source.close();
         }
     }
 
@@ -101,14 +100,13 @@ public class TableSourceProviderTest {
         insert(s2, SIMPLE, "SIMPLE");
 
         TableSourceProvider provider = new TableSourceProvider();
-        DataModelSource source = provider.open(SIMPLE, new URI("bulkloader:provider:SIMPLE"), new TestContext.Empty());
-
-        try {
+        try (DataModelSource source = provider.open(
+                SIMPLE,
+                new URI("bulkloader:provider:SIMPLE"),
+                new TestContext.Empty())) {
             assertThat(next(source), is(s1));
             assertThat(next(source), is(s2));
             assertThat(next(source), is(nullValue()));
-        } finally {
-            source.close();
         }
     }
 
@@ -121,11 +119,11 @@ public class TableSourceProviderTest {
         context.put("provider", "provider");
 
         TableSourceProvider provider = new TableSourceProvider();
-        DataModelSource source = provider.open(SIMPLE, new URI("bulkloader:provider:SIMPLE"), new TestContext.Empty());
-        try {
+        try (DataModelSource source = provider.open(
+                SIMPLE,
+                new URI("bulkloader:provider:SIMPLE"),
+                new TestContext.Empty())) {
             assertThat(next(source), is(nullValue()));
-        } finally {
-            source.close();
         }
     }
 
@@ -143,15 +141,10 @@ public class TableSourceProviderTest {
     }
 
     private <T> void insert(T simple, DataModelDefinition<T> def, String table) {
-        try {
-            TableInfo<T> info = new TableInfo<T>(def, table, Arrays.asList("NUMBER", "TEXT", "C_BOOL", "C_BYTE",
-                    "C_SHORT", "C_LONG", "C_FLOAT", "C_DOUBLE", "C_DECIMAL", "C_DATE", "C_TIME", "C_DATETIME"));
-            TableOutput<T> output = new TableOutput<T>(info, h2.open());
-            try {
-                output.write(simple);
-            } finally {
-                output.close();
-            }
+        TableInfo<T> info = new TableInfo<>(def, table, Arrays.asList("NUMBER", "TEXT", "C_BOOL", "C_BYTE",
+                "C_SHORT", "C_LONG", "C_FLOAT", "C_DOUBLE", "C_DECIMAL", "C_DATE", "C_TIME", "C_DATETIME"));
+        try (TableOutput<T> output = new TableOutput<>(info, h2.open())) {
+            output.write(simple);
         } catch (Exception e) {
             throw new AssertionError(e);
         }
@@ -164,5 +157,4 @@ public class TableSourceProviderTest {
         }
         return null;
     }
-
 }

--- a/thundergate-project/asakusa-thundergate-vocabulary/src/main/java/com/asakusafw/vocabulary/bulkloader/AttributeHelper.java
+++ b/thundergate-project/asakusa-thundergate-vocabulary/src/main/java/com/asakusafw/vocabulary/bulkloader/AttributeHelper.java
@@ -49,7 +49,7 @@ final class AttributeHelper {
     static List<String> getColumnNames(Class<?> modelType) {
         ColumnOrder original = modelType.getAnnotation(ColumnOrder.class);
         if (original != null) {
-            return new ArrayList<String>(Arrays.asList(original.value()));
+            return new ArrayList<>(Arrays.asList(original.value()));
         }
         TableModel meta = modelType.getAnnotation(TableModel.class);
         if (meta != null) {
@@ -67,7 +67,7 @@ final class AttributeHelper {
     static List<String> getPrimaryKeyNames(Class<?> modelType) {
         PrimaryKey original = modelType.getAnnotation(PrimaryKey.class);
         if (original != null) {
-            return new ArrayList<String>(Arrays.asList(original.value()));
+            return new ArrayList<>(Arrays.asList(original.value()));
         }
         TableModel meta = modelType.getAnnotation(TableModel.class);
         if (meta != null) {

--- a/thundergate-project/asakusa-thundergate-vocabulary/src/main/java/com/asakusafw/vocabulary/bulkloader/BulkLoadImporterDescription.java
+++ b/thundergate-project/asakusa-thundergate-vocabulary/src/main/java/com/asakusafw/vocabulary/bulkloader/BulkLoadImporterDescription.java
@@ -122,7 +122,7 @@ public abstract class BulkLoadImporterDescription implements ImporterDescription
         hash = hash * prime + hash(getTargetName());
         hash = hash * prime + hash(getModelType().getName());
         hash = hash * prime + hash(getTableName());
-        hash = hash * prime + hash(new HashSet<String>(getColumnNames()));
+        hash = hash * prime + hash(new HashSet<>(getColumnNames()));
         hash = hash * prime + hash(getWhere());
         return String.format("%016x", hash);
     }

--- a/thundergate-project/asakusa-thundergate-vocabulary/src/main/java/com/asakusafw/vocabulary/bulkloader/DupCheckDbExporterDescription.java
+++ b/thundergate-project/asakusa-thundergate-vocabulary/src/main/java/com/asakusafw/vocabulary/bulkloader/DupCheckDbExporterDescription.java
@@ -187,7 +187,7 @@ public abstract class DupCheckDbExporterDescription extends BulkLoadExporterDesc
         String errorTableName = getErrorTableName();
 
         // エラーコードカラムをエクスポート対象から外す
-        List<String> errorColumnNames = new ArrayList<String>(getErrorColumnNames());
+        List<String> errorColumnNames = new ArrayList<>(getErrorColumnNames());
         String errorCodeColumnName = getErrorCodeColumnName();
         errorColumnNames.remove(errorCodeColumnName);
 

--- a/thundergate-project/asakusa-thundergate/README
+++ b/thundergate-project/asakusa-thundergate/README
@@ -39,7 +39,7 @@ DBCleanerを構成するクラス。
 src/test配下のJunit実行には、以下の設定が必要である。
 1.データベースを作成
   以下のSQLを実行してDB/ユーザーを作成する。
-  ・実行するSQL：asakusa-thundergate\src\test\sql\create_utest_database.sql
+  ・実行するSQL：asakusa-thundergate/src/test/dist/bulkloader/sql/create_utest_database.sql
   ・上記SQLを実行すると、以下のデータベース/ユーザーが作成される。
     - データベース名：__asakusa_utest_thundergate
     - 接続ユーザー名：__asakusa_ut_tg

--- a/thundergate-project/asakusa-thundergate/src/main/dist/bulkloader/libexec/hadoop-build-cache.sh
+++ b/thundergate-project/asakusa-thundergate/src/main/dist/bulkloader/libexec/hadoop-build-cache.sh
@@ -20,7 +20,7 @@ usage() {
 Builds cache for ThunderGate.
 
 Usage:
-    $0 subcommand batch-id flow-id execution-id cache-path model-class
+    $0 subcommand batch-id flow-id execution-id cache-path model-class table-name [...]
 
 Parameters:
     subcommand
@@ -35,7 +35,11 @@ Parameters:
     cache-path
         path to the cache location
     model-class
-        Fully qualified class name of data model class
+        fully qualified class name of data model class
+    table-name
+        original table name
+    ...
+        extra arguments for Hadoop command
 EOF
 }
 
@@ -55,7 +59,7 @@ _TGC_ROOT="$(cd "$(dirname "$0")/.." ; pwd)"
 import "$_TGC_ROOT/conf/env.sh"
 import "$_TGC_ROOT/libexec/validate-env.sh"
 
-if [ $# -ne 6 ]
+if [ $# -lt 7 ]
 then
     echo "$@" 1>&2
     usage
@@ -73,6 +77,8 @@ shift
 _OPT_CACHE_PATH="$1"
 shift
 _OPT_MODEL_CLASS="$1"
+shift
+_OPT_TABLE_NAME="$1"
 shift
 
 # Move to home directory
@@ -96,6 +102,8 @@ echo "        Flow ID: $_OPT_FLOW_ID"
 echo "   Execution ID: $_OPT_EXECUTION_ID"
 echo "     Cache Path: $_OPT_CACHE_PATH"
 echo "      Data Type: $_OPT_MODEL_CLASS"
+echo "     Table Name: $_OPT_TABLE_NAME"
+echo "     Extra Args: $@"
 
 export HADOOP_CLASSPATH=""
 "$HADOOP_CMD" jar \
@@ -104,9 +112,11 @@ export HADOOP_CLASSPATH=""
     "$_TGC_CLASS_NAME" \
     -conf "$_TGC_PLUGIN_CONF" \
     -libjars "$_TGC_LIBJARS" \
+    "$@" \
     "$_OPT_SUBCOMMAND" \
     "$_OPT_CACHE_PATH" \
-    "$_OPT_MODEL_CLASS"
+    "$_OPT_MODEL_CLASS" \
+    "$_OPT_TABLE_NAME"
 
 _TGC_RET=$?
 if [ $_TGC_RET -ne 0 ]
@@ -117,7 +127,9 @@ then
     echo "   Main Class: $_TGC_CLASS_NAME" 1>&2
     echo "  Sub Command: $_OPT_SUBCOMMAND"  1>&2
     echo "   Cache Path: $_OPT_CACHE_PATH"  1>&2
-    echo "   Model Type: $_OPT_MODEL_CLASS"  1>&2
+    echo "    Data Type: $_OPT_MODEL_CLASS"  1>&2
+    echo "   Table Name: $_OPT_TABLE_NAME"  1>&2
     echo "    Libraries: -libjars $_TGC_LIBJARS"  1>&2
+    echo "   Extra Args: $@"  1>&2
     exit $_TGC_RET
 fi

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ExportTargetTableBean.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ExportTargetTableBean.java
@@ -37,19 +37,19 @@ public class ExportTargetTableBean {
     /**
      * Export中間TSVファイルに対応するカラム名。
      */
-    private List<String> exportTsvColumns = new ArrayList<String>();
+    private List<String> exportTsvColumns = new ArrayList<>();
     /**
      * Export対象テーブルのカラム名。
      */
-    private List<String> exportTableColumns = new ArrayList<String>();
+    private List<String> exportTableColumns = new ArrayList<>();
     /**
      * 異常データテーブルのカラム名。
      */
-    private List<String> errorTableColumns = new ArrayList<String>();
+    private List<String> errorTableColumns = new ArrayList<>();
     /**
      * キー項目のカラム名。
      */
-    private List<String> keyColumns = new ArrayList<String>();
+    private List<String> keyColumns = new ArrayList<>();
     /**
      * エラーコードを格納するカラム名。
      */
@@ -65,11 +65,11 @@ public class ExportTargetTableBean {
     /**
      * Export対象テーブルのデータをHDFS上に書き出す際のファイルパス。
      */
-    private List<String> dfsFilePaths = new ArrayList<String>();
+    private List<String> dfsFilePaths = new ArrayList<>();
     /**
      * DBサーバ上のExport対象ファイル。
      */
-    private List<File> exportFiles = new ArrayList<File>();
+    private List<File> exportFiles = new ArrayList<>();
     /**
      * Exportテンポラリテーブル名。
      */

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ExporterBean.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ExporterBean.java
@@ -74,7 +74,7 @@ public class ExporterBean {
      * @return エクスポート対象テーブル名の一覧
      */
     public List<String> getExportTargetTableList() {
-        return new ArrayList<String>(exportTargetTable.keySet());
+        return new ArrayList<>(exportTargetTable.keySet());
         // return exportTargetTable.keySet().iterator();
     }
     /**
@@ -97,7 +97,7 @@ public class ExporterBean {
      * @return インポート対象テーブル名の一覧
      */
     public List<String> getImportTargetTableList() {
-        return new ArrayList<String>(importTargetTable.keySet());
+        return new ArrayList<>(importTargetTable.keySet());
 //        return importTargetTable.keySet().iterator();
     }
     /**

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ImportBean.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ImportBean.java
@@ -79,7 +79,7 @@ public class ImportBean {
      * @return インポート対象テーブル名の一覧
      */
     public List<String> getImportTargetTableList() {
-         return new ArrayList<String>(targetTable.keySet());
+         return new ArrayList<>(targetTable.keySet());
 //        return targetTable.keySet().iterator();
     }
     /**

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ImportTargetTableBean.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/bean/ImportTargetTableBean.java
@@ -34,7 +34,7 @@ public class ImportTargetTableBean {
     /**
      * Import対象カラム。
      */
-    private List<String> importTargetColumns = new ArrayList<String>();
+    private List<String> importTargetColumns = new ArrayList<>();
     /**
      * 検索条件。
      */

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/DeleteCacheStorageLocal.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/DeleteCacheStorageLocal.java
@@ -201,7 +201,7 @@ public class DeleteCacheStorageLocal {
         return executor.submit(new Callable<Map<String, FileProtocol.Kind>>() {
             @Override
             public Map<String, FileProtocol.Kind> call() throws IOException {
-                Map<String, FileProtocol.Kind> results = new HashMap<String, FileProtocol.Kind>();
+                Map<String, FileProtocol.Kind> results = new HashMap<>();
                 FileList.Reader reader = provider.openReader();
                 try {
                     while (reader.next()) {
@@ -245,11 +245,11 @@ public class DeleteCacheStorageLocal {
         String hostName = ConfigurationLoader.getProperty(Constants.PROP_KEY_NAMENODE_HOST);
         String userName = ConfigurationLoader.getProperty(Constants.PROP_KEY_NAMENODE_USER);
         String scriptPath = ConfigurationLoader.getRemoteScriptPath(Constants.PATH_REMOTE_CACHE_DELETE);
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add(scriptPath);
         command.add(targetName);
 
-        Map<String, String> env = new HashMap<String, String>();
+        Map<String, String> env = new HashMap<>();
         env.putAll(ConfigurationLoader.getPropSubMap(Constants.PROP_PREFIX_HC_ENV));
         env.putAll(RuntimeContext.get().unapply());
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/GcCacheStorage.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/GcCacheStorage.java
@@ -139,7 +139,7 @@ public class GcCacheStorage {
         boolean green = true;
         try {
             LOG.info("TG-GCCACHE-01010", targetName, executionId);
-            List<LocalCacheInfo> locked = new ArrayList<LocalCacheInfo>();
+            List<LocalCacheInfo> locked = new ArrayList<>();
             for (LocalCacheInfo info : deleted) {
                 LOG.debugMessage("Trying to acquire a cache lock: cacheId={0}, targetName={1}, executionId={2}",
                         info.getId(), targetName, executionId);

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/GetCacheInfoLocal.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/GetCacheInfoLocal.java
@@ -199,7 +199,7 @@ public class GetCacheInfoLocal {
         return executor.submit(new Callable<Map<String, CacheInfo>>() {
             @Override
             public Map<String, CacheInfo> call() throws IOException {
-                Map<String, CacheInfo> results = new HashMap<String, CacheInfo>();
+                Map<String, CacheInfo> results = new HashMap<>();
                 FileList.Reader reader = provider.openReader();
                 try {
                     while (reader.next()) {
@@ -257,14 +257,14 @@ public class GetCacheInfoLocal {
         String hostName = ConfigurationLoader.getProperty(Constants.PROP_KEY_NAMENODE_HOST);
         String userName = ConfigurationLoader.getProperty(Constants.PROP_KEY_NAMENODE_USER);
         String scriptPath = ConfigurationLoader.getRemoteScriptPath(Constants.PATH_REMOTE_CACHE_INFO);
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add(scriptPath);
         command.add(targetName);
         command.add(batchId);
         command.add(jobflowId);
         command.add(executionId);
 
-        Map<String, String> env = new HashMap<String, String>();
+        Map<String, String> env = new HashMap<>();
         env.putAll(ConfigurationLoader.getPropSubMap(Constants.PROP_PREFIX_HC_ENV));
         env.putAll(RuntimeContext.get().unapply());
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/LocalCacheInfoRepository.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/cache/LocalCacheInfoRepository.java
@@ -321,7 +321,7 @@ public class LocalCacheInfoRepository {
             LOG.debugMessage("collecting deleted cache info");
             statement = connection.prepareStatement(sql);
             resultSet = statement.executeQuery();
-            List<LocalCacheInfo> results = new ArrayList<LocalCacheInfo>();
+            List<LocalCacheInfo> results = new ArrayList<>();
             while (resultSet.next()) {
                 LocalCacheInfo found = toCacheInfoObject(resultSet);
                 LOG.debugMessage("found deleted cache info: {0}", found.getId());

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/collector/ExportFileSend.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/collector/ExportFileSend.java
@@ -58,7 +58,7 @@ public class ExportFileSend {
     /**
      * ファイル名作成の為のマップ。
      */
-    Map<String, Integer> fileNameMap = new HashMap<String, Integer>();
+    Map<String, Integer> fileNameMap = new HashMap<>();
     /**
      * Export対象ファイルをDBサーバへ送信する。
      * <p>
@@ -165,7 +165,7 @@ public class ExportFileSend {
         long maxSize = Long.parseLong(ConfigurationLoader.getProperty(Constants.PROP_KEY_EXP_LOAD_MAX_SIZE));
 
         try {
-            TsvIoFactory<T> factory = new TsvIoFactory<T>(targetTableModel);
+            TsvIoFactory<T> factory = new TsvIoFactory<>(targetTableModel);
             Configuration conf = new Configuration();
             fs = FileSystem.get(new URI(filePath), conf);
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/ConfigurationLoader.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/ConfigurationLoader.java
@@ -52,7 +52,7 @@ public final class ConfigurationLoader {
 
     private static final Set<String> KEY_PATHS;
     static {
-        Set<String> keys = new HashSet<String>();
+        Set<String> keys = new HashSet<>();
         keys.add(Constants.PROP_KEY_LOG_CONF_PATH);
         keys.add(Constants.PROP_KEY_SSH_PATH);
         keys.add(Constants.PROP_KEY_IMP_FILE_DIR);
@@ -533,7 +533,7 @@ public final class ConfigurationLoader {
         if (prefix == null) {
             throw new IllegalArgumentException("prefix must not be null"); //$NON-NLS-1$
         }
-        Map<String, String> results = new HashMap<String, String>();
+        Map<String, String> results = new HashMap<>();
         for (Map.Entry<Object, Object> entry : prop.entrySet()) {
             if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
                 String key = (String) entry.getKey();
@@ -551,7 +551,7 @@ public final class ConfigurationLoader {
      */
     public static List<String> getPropStartWithString(String startString) {
         Set<Object> propSet = prop.keySet();
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
 
         for (Object o : propSet) {
             String key = (String) o;
@@ -567,7 +567,7 @@ public final class ConfigurationLoader {
      * @return プロパティのvalueが空でないkeyのリスト
      */
     public static List<String> getExistValueList(List<String> list) {
-        List<String> resultList = new ArrayList<String>();
+        List<String> resultList = new ArrayList<>();
         if (list == null || list.size() == 0) {
             return resultList;
         }

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/Constants.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/Constants.java
@@ -490,7 +490,7 @@ public final class Constants {
      * @return Export対象テーブルのシステムカラム
      */
     public static List<String> getSystemColumns() {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add(Constants.getSidColumnName());
         list.add(Constants.getVersionColumnName());
         list.add(Constants.getRegisteredDateTimeColumnName());
@@ -503,7 +503,7 @@ public final class Constants {
      * @return 異常データテーブルのシステムカラム
      */
     public static List<String> getErrorSystemColumns() {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add(Constants.getSidColumnName());
         list.add(Constants.getVersionColumnName());
         list.add(Constants.getRegisteredDateTimeColumnName());

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/DBAccessUtil.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/DBAccessUtil.java
@@ -128,7 +128,7 @@ public final class DBAccessUtil {
                 stmt.setString(1, executionId);
             }
             rs = DBConnection.executeQuery(stmt, sql, new String[] { executionId });
-            List<ExporterBean> beanList = new ArrayList<ExporterBean>();
+            List<ExporterBean> beanList = new ArrayList<>();
             while (rs.next()) {
                 ExporterBean bean = new ExporterBean();
                 bean.setJobflowSid(rs.getString("JOBFLOW_SID"));
@@ -171,7 +171,7 @@ public final class DBAccessUtil {
         Connection conn = null;
         PreparedStatement stmt = null;
         ResultSet rs = null;
-        List<ExportTempTableBean> beanList = new ArrayList<ExportTempTableBean>();
+        List<ExportTempTableBean> beanList = new ArrayList<>();
         try {
             conn = DBConnection.getConnection();
             stmt = conn.prepareStatement(sql);
@@ -216,7 +216,7 @@ public final class DBAccessUtil {
      */
     public static List<String> delErrorSystemColumn(List<String> tableColumn, String errorCodeColumn) {
         List<String> errorSystemColumns = Constants.getErrorSystemColumns();
-        List<String> sysColumn = new ArrayList<String>(errorSystemColumns);
+        List<String> sysColumn = new ArrayList<>(errorSystemColumns);
         sysColumn.add(errorCodeColumn);
         return delColumn(tableColumn, sysColumn);
     }
@@ -227,7 +227,7 @@ public final class DBAccessUtil {
      * @return 特定の要素を取り除いた配列
      */
     private static List<String> delColumn(List<String> tableColumn, List<String> delColumn) {
-        List<String> resultList = new ArrayList<String>();
+        List<String> resultList = new ArrayList<>();
 
         // カラム名のリストからシステムカラムを取り除く
         int tableCount = tableColumn.size();

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/FileNameUtil.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/FileNameUtil.java
@@ -162,7 +162,7 @@ public final class FileNameUtil {
         } catch (IOException e) {
             throw new BulkLoaderSystemException(e, CLASS, "TG-COMMON-00019", rawPaths);
         }
-        List<Path> results = new ArrayList<Path>();
+        List<Path> results = new ArrayList<>();
         for (String rawPath : rawPaths) {
             String resolved = variables.parse(rawPath, false);
             Path fullPath;

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/JobFlowParamLoader.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/JobFlowParamLoader.java
@@ -194,7 +194,7 @@ public class JobFlowParamLoader {
         if (fetchImporterParams(targetName, jobflowId, propFile) == false) {
             return false;
         }
-        Map<String, ImportTargetTableBean> cacheTables = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> cacheTables = new HashMap<>();
         for (Map.Entry<String, ImportTargetTableBean> entry : importTargetTables.entrySet()) {
             String tableName = entry.getKey();
             ImportTargetTableBean tableInfo = entry.getValue();
@@ -246,7 +246,7 @@ public class JobFlowParamLoader {
             String targetName,
             String jobflowId,
             String propFilePath) {
-        importTargetTables = new TreeMap<String, ImportTargetTableBean>();
+        importTargetTables = new TreeMap<>();
         String strTargetTable = importProp.getProperty(IMP_TARGET_TABLE);
         if (strTargetTable == null || strTargetTable.isEmpty()) {
             // Import対象テーブルがない場合は中身を生成せずに終了する
@@ -405,7 +405,7 @@ public class JobFlowParamLoader {
             String targetName,
             String jobflowId,
             String propFilePath) {
-        exportTargetTables = new TreeMap<String, ExportTargetTableBean>();
+        exportTargetTables = new TreeMap<>();
         String strTargetTable = exportProp.getProperty(EXP_TARGET_TABLE);
         if (strTargetTable == null || strTargetTable.equals("")) {
             // Export対象テーブルがない場合は中身を生成せずに終了する
@@ -482,7 +482,7 @@ public class JobFlowParamLoader {
                 } else if (EXP_HDFS_EXPORT_FILE.equals(keyMeans)) {
                     // HDFS上の出力パス
                     List<String> path = spritComma(value);
-                    List<String> pathList = new ArrayList<String>(path);
+                    List<String> pathList = new ArrayList<>(path);
                     bean.setDfsFilePaths(pathList);
                 } else {
                     // 設定が不明の場合は読み飛ばす
@@ -846,7 +846,7 @@ public class JobFlowParamLoader {
 
             // Export対象テーブルのカラムがExport中間TSVファイルに含まれる事を確認
             List<String> systemColumns = Constants.getSystemColumns();
-            List<String> allColumn = new ArrayList<String>(bean.getExportTsvColumn());
+            List<String> allColumn = new ArrayList<>(bean.getExportTsvColumn());
             allColumn.addAll(systemColumns);
             if (!includeColumnCheck(bean.getExportTableColumns(), allColumn)) {
                 LOG.error("TG-COMMON-00005",

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/MultiThreadedCopier.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/common/MultiThreadedCopier.java
@@ -52,10 +52,10 @@ public final class MultiThreadedCopier<T> {
         assert input != null;
         assert output != null;
         assert working != null;
-        this.outputChannel = new ArrayBlockingQueue<T>(working.size() + 1);
-        this.buffer = new ArrayBlockingQueue<T>(working.size() + 1, false, working);
+        this.outputChannel = new ArrayBlockingQueue<>(working.size() + 1);
+        this.buffer = new ArrayBlockingQueue<>(working.size() + 1, false, working);
         this.input = input;
-        this.task = new OutputTask<T>(outputChannel, buffer, output);
+        this.task = new OutputTask<>(outputChannel, buffer, output);
         this.task.setDaemon(true);
     }
 
@@ -87,7 +87,7 @@ public final class MultiThreadedCopier<T> {
         if (working.isEmpty()) {
             throw new IllegalArgumentException("working must not be empty"); //$NON-NLS-1$
         }
-        return new MultiThreadedCopier<T>(input, output, working).process();
+        return new MultiThreadedCopier<>(input, output, working).process();
     }
 
     private long process() throws IOException, InterruptedException {
@@ -148,7 +148,7 @@ public final class MultiThreadedCopier<T> {
 
         final AtomicBoolean finished = new AtomicBoolean();
 
-        final AtomicReference<Throwable> occurred = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> occurred = new AtomicReference<>();
 
         long count;
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/exporter/ExportFileLoad.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/exporter/ExportFileLoad.java
@@ -459,7 +459,7 @@ public class ExportFileLoad {
         assert tableBean != null;
         List<String> columns = tableBean.getExportTsvColumn();
         columns = DBAccessUtil.delSystemColumn(columns);
-        columns = new ArrayList<String>(columns);
+        columns = new ArrayList<>(columns);
 
         if (tableBean.isDuplicateCheck() == false) {
             int columnSize = columns.size();
@@ -469,7 +469,7 @@ public class ExportFileLoad {
             }
         } else {
             // カラム->テーブル表を作成
-            Map<String, String> columnMap = new HashMap<String, String>();
+            Map<String, String> columnMap = new HashMap<>();
             for (String columnName : tableBean.getErrorTableColumns()) {
                 columnMap.put(columnName, tableBean.getErrorTableName());
             }

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/exporter/ExportFileReceive.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/exporter/ExportFileReceive.java
@@ -80,7 +80,7 @@ public class ExportFileReceive {
             int fileSeq = 0;
 
             // プロファイル用のテーブル
-            Map<String, TableTransferProfile> profiles = new TreeMap<String, TableTransferProfile>();
+            Map<String, TableTransferProfile> profiles = new TreeMap<>();
 
             while (reader.next()) {
                 FileProtocol protocol = reader.getCurrentProtocol();
@@ -280,7 +280,7 @@ public class ExportFileReceive {
         String userName = ConfigurationLoader.getProperty(Constants.PROP_KEY_NAMENODE_USER);
         String scriptPath = ConfigurationLoader.getRemoteScriptPath(Constants.PATH_REMOTE_COLLECTOR);
         String variableTable = Constants.createVariableTable().toSerialString();
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add(scriptPath);
         command.add(targetName);
         command.add(batchId);
@@ -288,7 +288,7 @@ public class ExportFileReceive {
         command.add(executionId);
         command.add(variableTable);
 
-        Map<String, String> env = new HashMap<String, String>();
+        Map<String, String> env = new HashMap<>();
         env.putAll(ConfigurationLoader.getPropSubMap(Constants.PROP_PREFIX_HC_ENV));
         env.putAll(RuntimeContext.get().unapply());
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/exporter/LockRelease.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/exporter/LockRelease.java
@@ -206,7 +206,7 @@ public class LockRelease {
     private Set<String> mergingIOTable(
             List<String> exportTargetTableList,
             List<String> importTargetTableList) {
-        Set<String> set = new LinkedHashSet<String>();
+        Set<String> set = new LinkedHashSet<>();
         for (String exportTable : exportTargetTableList) {
             set.add(exportTable);
         }

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/importer/ImportFileSend.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/importer/ImportFileSend.java
@@ -133,9 +133,9 @@ public class ImportFileSend {
 
     private List<String> arrangeSendOrder(ImportBean bean) {
         assert bean != null;
-        final Map<String, ImportTargetTableBean> tables = new HashMap<String, ImportTargetTableBean>();
-        final Map<String, Long> sizes = new HashMap<String, Long>();
-        List<String> tableNames = new ArrayList<String>(bean.getImportTargetTableList());
+        final Map<String, ImportTargetTableBean> tables = new HashMap<>();
+        final Map<String, Long> sizes = new HashMap<>();
+        List<String> tableNames = new ArrayList<>(bean.getImportTargetTableList());
         for (String tableName : tableNames) {
             ImportTargetTableBean tableBean = bean.getTargetTable(tableName);
             tables.put(tableName, tableBean);
@@ -244,7 +244,7 @@ public class ImportFileSend {
         String userName = ConfigurationLoader.getProperty(Constants.PROP_KEY_NAMENODE_USER);
         String scriptPath = ConfigurationLoader.getRemoteScriptPath(Constants.PATH_REMOTE_EXTRACTOR);
         String variableTable = Constants.createVariableTable().toSerialString();
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add(scriptPath);
         command.add(targetName);
         command.add(batchId);
@@ -252,7 +252,7 @@ public class ImportFileSend {
         command.add(executionId);
         command.add(variableTable);
 
-        Map<String, String> env = new HashMap<String, String>();
+        Map<String, String> env = new HashMap<>();
         env.putAll(ConfigurationLoader.getPropSubMap(Constants.PROP_PREFIX_HC_ENV));
         env.putAll(RuntimeContext.get().unapply());
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/importer/ImportProtocolDecide.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/importer/ImportProtocolDecide.java
@@ -220,10 +220,10 @@ public class ImportProtocolDecide {
                     tableName, remoteInfo.getTableName()));
             return null;
         }
-        if (remoteInfo.getColumnNames().equals(new HashSet<String>(tableInfo.getImportTargetColumns())) == false) {
+        if (remoteInfo.getColumnNames().equals(new HashSet<>(tableInfo.getImportTargetColumns())) == false) {
             LOG.warn("TG-IMPORTER-11010", tableName, cacheId, MessageFormat.format(
                     "Inconsistent column set: expected {0}, but was {1}",
-                    new TreeSet<String>(tableInfo.getImportTargetColumns()), remoteInfo.getColumnNames()));
+                    new TreeSet<>(tableInfo.getImportTargetColumns()), remoteInfo.getColumnNames()));
             return null;
         }
 

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/importer/TargetDataLock.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/importer/TargetDataLock.java
@@ -387,7 +387,7 @@ public class TargetDataLock {
             LOG.info("TG-IMPORTER-02008", selectSql.toString());
             stmt = conn.prepareStatement(selectSql.toString());
             rs = DBConnection.executeQuery(stmt, selectSql.toString(), new String[0]);
-            Map<String, String> tableLockStatus = new HashMap<String, String>();
+            Map<String, String> tableLockStatus = new HashMap<>();
             while (rs.next()) {
                 String key = rs.getString("TABLE_NAME");
                 String value = rs.getString("JOBFLOW_SID");

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/tools/DBCleaner.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/tools/DBCleaner.java
@@ -223,7 +223,7 @@ public final class DBCleaner {
         String rlSql = "DELETE FROM ";
 
         // レコードロックテーブルを検索
-        List<String> rlList = new ArrayList<String>();
+        List<String> rlList = new ArrayList<>();
         PreparedStatement stmt = null;
         ResultSet rs = null;
         try {
@@ -334,8 +334,8 @@ public final class DBCleaner {
         String delSql = "DELETE FROM EXPORT_TEMP_TABLE";
 
         // エクスポートテンポラリ管理テーブルを検索
-        List<String> tempTableList = new ArrayList<String>();
-        List<String> dupTableList = new ArrayList<String>();
+        List<String> tempTableList = new ArrayList<>();
+        List<String> dupTableList = new ArrayList<>();
         PreparedStatement stmt = null;
         ResultSet rs = null;
         try {

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/transfer/OpenSshFileListProvider.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/transfer/OpenSshFileListProvider.java
@@ -94,7 +94,7 @@ public class OpenSshFileListProvider extends StreamFileListProvider {
         assert hostName != null;
         assert remoteCommand != null;
         assert remoteEnv != null;
-        List<String> localCommand = new ArrayList<String>();
+        List<String> localCommand = new ArrayList<>();
         localCommand.add(sshExec);
         localCommand.add("-l");
         localCommand.add(userName);

--- a/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/transfer/StreamFileListProvider.java
+++ b/thundergate-project/asakusa-thundergate/src/main/java/com/asakusafw/bulkloader/transfer/StreamFileListProvider.java
@@ -32,7 +32,7 @@ import com.asakusafw.bulkloader.common.StreamRedirectThread;
  */
 public abstract class StreamFileListProvider implements FileListProvider {
 
-    private final List<Thread> running = new ArrayList<Thread>();
+    private final List<Thread> running = new ArrayList<>();
 
     @Override
     public FileList.Reader openReader() throws IOException {

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/DeleteCacheStorageLocalTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/DeleteCacheStorageLocalTest.java
@@ -127,7 +127,7 @@ public class DeleteCacheStorageLocalTest {
      */
     @Test(timeout =  5000L)
     public void nothing() throws Exception {
-        List<LocalCacheInfo> list = new ArrayList<LocalCacheInfo>();
+        List<LocalCacheInfo> list = new ArrayList<>();
         Map<String, Kind> results = new Mock().delete(list, "dummy");
         assertThat(results.size(), is(0));
     }
@@ -140,7 +140,7 @@ public class DeleteCacheStorageLocalTest {
     public void delete() throws Exception {
         prepare(info1);
 
-        List<LocalCacheInfo> list = new ArrayList<LocalCacheInfo>();
+        List<LocalCacheInfo> list = new ArrayList<>();
         list.add(info1);
 
         Map<String, Kind> results = new Mock().delete(list, "dummy");
@@ -154,7 +154,7 @@ public class DeleteCacheStorageLocalTest {
      */
     @Test(timeout =  5000L)
     public void delete_missing() throws Exception {
-        List<LocalCacheInfo> list = new ArrayList<LocalCacheInfo>();
+        List<LocalCacheInfo> list = new ArrayList<>();
         list.add(info1);
 
         Map<String, Kind> results = new Mock().delete(list, "dummy");
@@ -170,7 +170,7 @@ public class DeleteCacheStorageLocalTest {
     public void delete_multiple() throws Exception {
         prepare(info1, info3);
 
-        List<LocalCacheInfo> list = new ArrayList<LocalCacheInfo>();
+        List<LocalCacheInfo> list = new ArrayList<>();
         list.add(info1);
         list.add(info2);
         list.add(info3);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/DeleteCacheStorageRemoteTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/DeleteCacheStorageRemoteTest.java
@@ -209,7 +209,7 @@ public class DeleteCacheStorageRemoteTest {
     }
 
     private List<FileProtocol> collect(byte[] byteArray) throws IOException {
-        List<FileProtocol> results = new ArrayList<FileProtocol>();
+        List<FileProtocol> results = new ArrayList<>();
         ByteArrayInputStream input = new ByteArrayInputStream(byteArray);
         FileList.Reader reader = FileList.createReader(input);
         while (reader.next()) {

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/GcCacheStorageTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/GcCacheStorageTest.java
@@ -319,7 +319,7 @@ public class GcCacheStorageTest {
 
     static class Mock extends GcCacheStorage {
 
-        final Map<String, FileProtocol.Kind> results = new LinkedHashMap<String, FileProtocol.Kind>();
+        final Map<String, FileProtocol.Kind> results = new LinkedHashMap<>();
 
         Mock put(LocalCacheInfo info, FileProtocol.Kind kind) {
             results.put(info.getPath(), kind);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/GetCacheInfoLocalTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/GetCacheInfoLocalTest.java
@@ -114,7 +114,7 @@ public class GetCacheInfoLocalTest {
     @Test(timeout =  5000L)
     public void withoutCache() throws Exception {
         ImportBean bean = createBean();
-        Map<String, ImportTargetTableBean> map = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> map = new HashMap<>();
         ImportTargetTableBean table = new ImportTargetTableBean();
         table.setDfsFilePath("normal");
         map.put("normal", table);
@@ -132,7 +132,7 @@ public class GetCacheInfoLocalTest {
     @Test(timeout =  5000L)
     public void nothing() throws Exception {
         ImportBean bean = createBean();
-        Map<String, ImportTargetTableBean> map = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> map = new HashMap<>();
         ImportTargetTableBean table = new ImportTargetTableBean();
         table.setDfsFilePath("nothing");
         table.setCacheId("nothing");
@@ -167,7 +167,7 @@ public class GetCacheInfoLocalTest {
         }
 
         ImportBean bean = createBean();
-        Map<String, ImportTargetTableBean> map = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> map = new HashMap<>();
         ImportTargetTableBean table = new ImportTargetTableBean();
         table.setDfsFilePath("available");
         table.setCacheId("available");
@@ -203,7 +203,7 @@ public class GetCacheInfoLocalTest {
         }
 
         ImportBean bean = createBean();
-        Map<String, ImportTargetTableBean> map = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> map = new HashMap<>();
 
         ImportTargetTableBean table1 = new ImportTargetTableBean();
         table1.setDfsFilePath("nothing1");
@@ -251,7 +251,7 @@ public class GetCacheInfoLocalTest {
     @Test(timeout =  5000L)
     public void fail() throws Exception {
         ImportBean bean = createBean();
-        Map<String, ImportTargetTableBean> map = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> map = new HashMap<>();
         ImportTargetTableBean table = new ImportTargetTableBean();
         table.setDfsFilePath("nothing");
         table.setCacheId("nothing");

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/GetCacheInfoRemoteTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/GetCacheInfoRemoteTest.java
@@ -231,7 +231,7 @@ public class GetCacheInfoRemoteTest {
     }
 
     private List<FileProtocol> collect(byte[] byteArray) throws IOException {
-        List<FileProtocol> results = new ArrayList<FileProtocol>();
+        List<FileProtocol> results = new ArrayList<>();
         ByteArrayInputStream input = new ByteArrayInputStream(byteArray);
         FileList.Reader reader = FileList.createReader(input);
         while (reader.next()) {

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/TestDataModel.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/TestDataModel.java
@@ -24,11 +24,14 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.VLongWritable;
 import org.apache.hadoop.io.Writable;
 
+import com.asakusafw.runtime.value.DateTime;
+import com.asakusafw.runtime.value.DateTimeOption;
 import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
 
 /**
  * Cache testing data model.
  */
+@SuppressWarnings("deprecation")
 public class TestDataModel implements Writable, ThunderGateCacheSupport, Comparable<TestDataModel> {
 
     /**
@@ -42,9 +45,37 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
     public final Text value = new Text();
 
     /**
+     * modified.
+     */
+    public final DateTimeOption timestamp = new DateTimeOption(new DateTime());
+
+    /**
      * deleted.
      */
     public final BooleanWritable deleted = new BooleanWritable();
+
+    /**
+     * Set SID and value.
+     * @param text the value
+     * @return this
+     */
+    public TestDataModel next(String text) {
+        this.systemId.set(this.systemId.get() + 1);
+        this.value.set(text);
+        return this;
+    }
+
+    /**
+     * Set timestamp.
+     * @param year year (1-...)
+     * @param month month (1-12)
+     * @param day day (1-31)
+     * @return this
+     */
+    public TestDataModel on(int year, int month, int day) {
+        timestamp.modify(new DateTime(year, month, day, 0, 0, 0));
+        return this;
+    }
 
     /**
      * Creates a copy of this.
@@ -54,6 +85,7 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
         TestDataModel copy = new TestDataModel();
         copy.systemId.set(systemId.get());
         copy.value.set(value);
+        copy.timestamp.copyFrom(timestamp);
         copy.deleted.set(deleted.get());
         return copy;
     }
@@ -75,7 +107,7 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
 
     @Override
     public long __tgc__Timestamp() {
-        return 0;
+        return timestamp.get().getElapsedSeconds();
     }
 
     @Override
@@ -87,6 +119,7 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
     public void write(DataOutput out) throws IOException {
         systemId.write(out);
         value.write(out);
+        timestamp.write(out);
         deleted.write(out);
     }
 
@@ -94,6 +127,7 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
     public void readFields(DataInput in) throws IOException {
         systemId.readFields(in);
         value.readFields(in);
+        timestamp.readFields(in);
         deleted.readFields(in);
     }
 
@@ -109,6 +143,8 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
         builder.append(systemId);
         builder.append(", value=");
         builder.append(value);
+        builder.append(", timestamp=");
+        builder.append(timestamp);
         builder.append(", deleted=");
         builder.append(deleted);
         builder.append("]");

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/TestDataModel.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/cache/TestDataModel.java
@@ -74,6 +74,11 @@ public class TestDataModel implements Writable, ThunderGateCacheSupport, Compara
     }
 
     @Override
+    public long __tgc__Timestamp() {
+        return 0;
+    }
+
+    @Override
     public boolean __tgc__Deleted() {
         return deleted.get();
     }

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/collector/ExportFileSendTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/collector/ExportFileSendTest.java
@@ -114,9 +114,9 @@ public class ExportFileSendTest {
     @Test
     public void sendExportFileTest01() throws Exception {
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("src/test/data/collector1");
         list1.add("${execution_id}/data/collector2");
         table1.setDfsFilePaths(list1);
@@ -124,7 +124,7 @@ public class ExportFileSendTest {
         targetTable.put("EXP_TARGET1", table1);
 
         ExportTargetTableBean table2 = new ExportTargetTableBean();
-        List<String> list2 = new ArrayList<String>();
+        List<String> list2 = new ArrayList<>();
         list2.add("src/test/data/collector3");
         table2.setDfsFilePaths(list2);
         table2.setExportTargetType(NullWritable.class);
@@ -163,9 +163,9 @@ public class ExportFileSendTest {
     @Test
     public void sendExportFileTest05() throws Exception {
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("/src/test/data/collector1");
         list1.add("/${user}/${execution_id}/data/collector2");
         table1.setDfsFilePaths(list1);
@@ -173,7 +173,7 @@ public class ExportFileSendTest {
         targetTable.put("EXP_TARGET1", table1);
 
         ExportTargetTableBean table2 = new ExportTargetTableBean();
-        List<String> list2 = new ArrayList<String>();
+        List<String> list2 = new ArrayList<>();
         list2.add("/src/test/data/collector3");
         table2.setDfsFilePaths(list2);
         table2.setExportTargetType(NullWritable.class);
@@ -485,7 +485,7 @@ public class ExportFileSendTest {
 }
 
 class DummyExportFileSend extends ExportFileSend {
-    List<String> dirs = new ArrayList<String>();
+    List<String> dirs = new ArrayList<>();
     @Override
     protected <T extends Writable> long send(
             Class<T> targetTableModel,

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/common/ConfigurationLoaderTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/common/ConfigurationLoaderTest.java
@@ -136,7 +136,7 @@ public class ConfigurationLoaderTest {
     @Test
     public void checkEnvTest01() throws Exception {
         ConfigurationLoader.init(properties_db, true, false);
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put(Constants.ASAKUSA_HOME, ConfigurationLoader.getEnvProperty(Constants.ASAKUSA_HOME));
         m.put(Constants.THUNDER_GATE_HOME, null);
         ConfigurationLoader.setEnv(m);
@@ -163,7 +163,7 @@ public class ConfigurationLoaderTest {
     @Test
     public void checkEnvTest02() throws Exception {
         ConfigurationLoader.init(properties_db, true, false);
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put(Constants.ASAKUSA_HOME, ConfigurationLoader.getEnvProperty(Constants.ASAKUSA_HOME));
         m.put(Constants.THUNDER_GATE_HOME, "J:\temp");
         ConfigurationLoader.setEnv(m);
@@ -194,7 +194,7 @@ public class ConfigurationLoaderTest {
     @Test
     public void checkEnvTest03() throws Exception {
         ConfigurationLoader.init(properties_db, true, false);
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put(Constants.ASAKUSA_HOME, null);
         m.put(Constants.THUNDER_GATE_HOME, ConfigurationLoader.getEnvProperty(Constants.THUNDER_GATE_HOME));
         ConfigurationLoader.setEnv(m);
@@ -221,7 +221,7 @@ public class ConfigurationLoaderTest {
     @Test
     public void checkEnvTest04() throws Exception {
         ConfigurationLoader.init(properties_db, true, false);
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put(Constants.ASAKUSA_HOME, "J:\temp");
         m.put(Constants.THUNDER_GATE_HOME, ConfigurationLoader.getEnvProperty(Constants.THUNDER_GATE_HOME));
         ConfigurationLoader.setEnv(m);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/common/DBAccessUtilTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/common/DBAccessUtilTest.java
@@ -236,7 +236,7 @@ public class DBAccessUtilTest {
     @Test
     public void delSystemColumn01() throws Exception {
         // テスト対象クラス実行
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("SID");
         list.add("VERSION_NO");
         list.add("RGST_DATE");
@@ -265,7 +265,7 @@ public class DBAccessUtilTest {
     @Test
     public void delSystemColumn02() throws Exception {
         // テスト対象クラス実行
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("RGST_DATE");
         list.add("UPDT_DATE");
         list.add("TEMP_SID");
@@ -292,7 +292,7 @@ public class DBAccessUtilTest {
     @Test
     public void delErrorSystemColumn01() throws Exception {
         // テスト対象クラス実行
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("SID");
         list.add("VERSION_NO");
         list.add("RGST_DATE");
@@ -326,7 +326,7 @@ public class DBAccessUtilTest {
     @Test
     public void joinColumnArray01() throws Exception {
         // テスト対象クラス実行
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("SID");
         list.add("VERSION_NO");
         list.add("RGST_DATE");

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/common/JobFlowParamLoaderTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/common/JobFlowParamLoaderTest.java
@@ -170,7 +170,7 @@ public class JobFlowParamLoaderTest {
         VariableTable table = new VariableTable();
         table.defineVariable("user_name", "asakusa");
         table.defineVariable("user_pass", "hadoop");
-        Map<String, String> env = new HashMap<String, String>();
+        Map<String, String> env = new HashMap<>();
         env.put(Constants.THUNDER_GATE_HOME, System.getenv(Constants.THUNDER_GATE_HOME));
         env.put(Constants.ENV_ARGS, table.toSerialString());
         ConfigurationLoader.setEnv(env);
@@ -266,7 +266,7 @@ public class JobFlowParamLoaderTest {
         // 環境変数を設定
         VariableTable table = new VariableTable();
         table.defineVariable("user_pass", "hadoop");
-        Map<String, String> env = new HashMap<String, String>();
+        Map<String, String> env = new HashMap<>();
         env.put(Constants.THUNDER_GATE_HOME, System.getenv(Constants.THUNDER_GATE_HOME));
         env.put(Constants.ENV_ARGS, table.toSerialString());
         ConfigurationLoader.setEnv(env);
@@ -648,7 +648,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -718,7 +718,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setSearchCondition("INTDATA1=11");
         tableBean1.setUseCache(false);
@@ -773,7 +773,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -810,7 +810,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -847,7 +847,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -877,7 +877,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -907,7 +907,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -944,7 +944,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -981,7 +981,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -1018,7 +1018,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -1055,7 +1055,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -1125,7 +1125,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -1159,7 +1159,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -1193,7 +1193,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(false);
@@ -1214,7 +1214,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1239,7 +1239,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table2.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list2 = new ArrayList<String>();
+        List<String> list2 = new ArrayList<>();
         list2.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table2.setDfsFilePaths(list2);
         targetTable.put("EXP_TARGET2", table2);
@@ -1267,7 +1267,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1288,7 +1288,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1313,7 +1313,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table2.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list2 = new ArrayList<String>();
+        List<String> list2 = new ArrayList<>();
         list2.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table2.setDfsFilePaths(list2);
         targetTable.put("EXP_TARGET2", table2);
@@ -1338,7 +1338,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1359,7 +1359,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1404,7 +1404,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1425,7 +1425,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1463,7 +1463,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1484,7 +1484,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1522,7 +1522,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1543,7 +1543,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1581,7 +1581,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1602,7 +1602,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1633,7 +1633,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1654,7 +1654,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1678,7 +1678,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1699,7 +1699,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1723,7 +1723,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1744,7 +1744,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1775,12 +1775,12 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setExportTsvColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         table1.setExportTableColumns(Arrays.asList(new String[]{"TEXTDATA1"}));
         table1.setExportTargetType(this.getClass());
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1788,7 +1788,7 @@ public class JobFlowParamLoaderTest {
         table2.setExportTsvColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         table2.setExportTableColumns(Arrays.asList(new String[]{"TEXTDATA1"}));
         table2.setExportTargetType(null);
-        List<String> list2 = new ArrayList<String>();
+        List<String> list2 = new ArrayList<>();
         list2.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table2.setDfsFilePaths(list2);
         targetTable.put("EXP_TARGET2", table2);
@@ -1812,7 +1812,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setExportTsvColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         table1.setExportTableColumns(Arrays.asList(new String[]{"TEXTDATA1"}));
@@ -1822,7 +1822,7 @@ public class JobFlowParamLoaderTest {
         table2.setExportTsvColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         table2.setExportTableColumns(Arrays.asList(new String[]{"TEXTDATA1"}));
         table2.setExportTargetType(this.getClass());
-        List<String> list2 = new ArrayList<String>();
+        List<String> list2 = new ArrayList<>();
         list2.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table2.setDfsFilePaths(list2);
         targetTable.put("EXP_TARGET2", table2);
@@ -1832,7 +1832,7 @@ public class JobFlowParamLoaderTest {
         assertFalse(result);
 
         // 設定変更
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add(null);
         table1.setDfsFilePaths(list1);
 
@@ -1855,7 +1855,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(true);
@@ -1876,7 +1876,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1900,7 +1900,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(false);
@@ -1921,7 +1921,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);
@@ -1945,7 +1945,7 @@ public class JobFlowParamLoaderTest {
         JobFlowParamLoader loader = new JobFlowParamLoader();
 
         // 設定
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         // 重複チェックを行うか否か
         table1.setDuplicateCheck(false);
@@ -1970,7 +1970,7 @@ public class JobFlowParamLoaderTest {
         // Export対象テーブルに対応するJavaBeanのクラス名
         table1.setExportTargetType(this.getClass());
         // Export対象テーブルのデータをHDFS上に書き出す際のファイルパス
-        List<String> list1 = new ArrayList<String>();
+        List<String> list1 = new ArrayList<>();
         list1.add("hdfs://localhost/user/asakusa/import/11/XXX_1");
         table1.setDfsFilePaths(list1);
         targetTable.put("EXP_TARGET1", table1);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportDataCopyTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportDataCopyTest.java
@@ -96,7 +96,7 @@ public class ExportDataCopyTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1");
@@ -173,7 +173,7 @@ public class ExportDataCopyTest {
         ConfigurationLoader.setProperty(prop);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1");
@@ -239,7 +239,7 @@ public class ExportDataCopyTest {
         ConfigurationLoader.setProperty(prop);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1");
@@ -305,7 +305,7 @@ public class ExportDataCopyTest {
         ConfigurationLoader.setProperty(prop);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1");
@@ -361,7 +361,7 @@ public class ExportDataCopyTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1");
@@ -428,7 +428,7 @@ public class ExportDataCopyTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1_1");
@@ -502,7 +502,7 @@ public class ExportDataCopyTest {
         ConfigurationLoader.setProperty(prop);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.setExportTempTableName("TEMP_IMPORT_TARGET1");

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportFileDeleteTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportFileDeleteTest.java
@@ -96,7 +96,7 @@ public class ExportFileDeleteTest {
         importFile3.createNewFile();
 
         // ExporterBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean bean1 = new ExportTargetTableBean();
         bean1.addExportFile(importFile1);
         bean1.addExportFile(importFile2);
@@ -137,7 +137,7 @@ public class ExportFileDeleteTest {
         File importFile3 = new File(dumpDir, "EXP_IMPORT_TARGET3.tsv");
 
         // ExporterBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean bean1 = new ExportTargetTableBean();
         bean1.addExportFile(importFile1);
         bean1.addExportFile(importFile2);
@@ -175,7 +175,7 @@ public class ExportFileDeleteTest {
         File importFile3 = null;
 
         // ExporterBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean bean1 = new ExportTargetTableBean();
         bean1.addExportFile(importFile1);
         bean1.addExportFile(importFile2);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportFileLoadTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportFileLoadTest.java
@@ -94,7 +94,7 @@ public class ExportFileLoadTest {
     @Test
     public void loadFileTest01() throws Exception {
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.addExportFile(new File(new File ("src/test/data/exporter/EXP_EXP_TARGET1_1.tsv").getAbsolutePath()));
@@ -189,7 +189,7 @@ public class ExportFileLoadTest {
         util1.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(false);
         table1.addExportFile(new File(new File ("src/test/data/exporter/EXP_EXP_TARGET1_1.tsv").getAbsolutePath()));
@@ -268,7 +268,7 @@ public class ExportFileLoadTest {
         util1.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(false);
         table1.addExportFile(new File(new File ("src/test/data/exporter/EXP_EXP_TARGET1_1.tsv").getAbsolutePath()));
@@ -320,7 +320,7 @@ public class ExportFileLoadTest {
         util1.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.addExportFile(new File(new File ("src/test/data/exporter/EXP_EXP_TARGET1_4.tsv").getAbsolutePath()));
@@ -391,7 +391,7 @@ public class ExportFileLoadTest {
         util1.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setDuplicateCheck(true);
         table1.addExportFile(new File(new File ("src/test/data/exporter/EXP_EXP_TARGET1_1.tsv").getAbsolutePath()));
@@ -453,7 +453,7 @@ public class ExportFileLoadTest {
        util1.storeToDatabase(false);
 
        // ExportBeanを生成
-       Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+       Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
        ExportTargetTableBean table1 = new ExportTargetTableBean();
        table1.setDuplicateCheck(true);
        table1.addExportFile(new File(new File ("src/test/data/exporter/EXP_EXP_TARGET1_1.tsv").getAbsolutePath()));

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportFileReceiveTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/ExportFileReceiveTest.java
@@ -112,7 +112,7 @@ public class ExportFileReceiveTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         targetTable.put("EXP_TARGET1", table1);
         ExportTargetTableBean table2 = new ExportTargetTableBean();
@@ -160,7 +160,7 @@ public class ExportFileReceiveTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         targetTable.put("EXP_TARGET1", table1);
         ExportTargetTableBean table2 = new ExportTargetTableBean();
@@ -208,7 +208,7 @@ public class ExportFileReceiveTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         targetTable.put("EXP_TARGET1", table1);
         ExportTargetTableBean table2 = new ExportTargetTableBean();
@@ -254,7 +254,7 @@ public class ExportFileReceiveTest {
 //        String pattern = "patternR01";
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         targetTable.put("EXP_TARGET11", table1);
         ExportTargetTableBean table2 = new ExportTargetTableBean();
@@ -292,7 +292,7 @@ public class ExportFileReceiveTest {
 //        String pattern = "patternR01";
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         targetTable.put("EXP_TARGET1", table1);
         ExportTargetTableBean table2 = new ExportTargetTableBean();
@@ -336,7 +336,7 @@ public class ExportFileReceiveTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         targetTable.put("EXP_TARGET1", table1);
         ExportTargetTableBean table2 = new ExportTargetTableBean();

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/JudgeExecProcessTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/JudgeExecProcessTest.java
@@ -86,7 +86,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -133,7 +133,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -180,7 +180,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -237,7 +237,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -294,7 +294,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -351,7 +351,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -408,7 +408,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -466,7 +466,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         bean.setExportTargetTable(targetTable);
 
         Properties p = ConfigurationLoader.getProperty();
@@ -510,7 +510,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid(null);
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);
@@ -556,7 +556,7 @@ public class JudgeExecProcessTest {
         bean.setJobflowSid("11");
         bean.setJobflowId("jobflow1");
         bean.setExecutionId("11-1");
-        Map<String, ExportTargetTableBean> targetTable = new HashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> targetTable = new HashMap<>();
         targetTable.put("table1", new ExportTargetTableBean());
         targetTable.put("table2", new ExportTargetTableBean());
         bean.setExportTargetTable(targetTable);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/LockReleaseTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/exporter/LockReleaseTest.java
@@ -126,7 +126,7 @@ public class LockReleaseTest {
 
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setExportTempTableName(tempTable1);
         table1.setDuplicateFlagTableName("EXPORT_TEMP_TEST_01_DF");
@@ -135,7 +135,7 @@ public class LockReleaseTest {
         table2.setExportTempTableName(tempTable2);
         table2.setDuplicateFlagTableName("EXPORT_TEMP_TEST_02_DF");
         exportTargetTable.put("IMPORT_TARGET2", table2);
-        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<>();
         ImportTargetTableBean table3 = new ImportTargetTableBean();
         importTargetTable.put("IMPORT_TARGET1", table3);
         ImportTargetTableBean table4 = new ImportTargetTableBean();
@@ -188,8 +188,8 @@ public class LockReleaseTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<String, ExportTargetTableBean>();
-        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<>();
+        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<>();
         ImportTargetTableBean table1 = new ImportTargetTableBean();
         importTargetTable.put("IMPORT_TARGET1", table1);
         ImportTargetTableBean table2 = new ImportTargetTableBean();
@@ -269,10 +269,10 @@ public class LockReleaseTest {
         util.storeToDatabase(false);
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         exportTargetTable.put("IMPORT_TARGET1", table1);
-        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<>();
         ImportTargetTableBean table4 = new ImportTargetTableBean();
         importTargetTable.put("IMPORT_TARGET2", table4);
         ExporterBean bean = new ExporterBean();
@@ -328,8 +328,8 @@ public class LockReleaseTest {
     @Test
     public void releaseLockTest05() throws Exception {
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<String, ExportTargetTableBean>();
-        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<>();
+        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<>();
         ExporterBean bean = new ExporterBean();
         bean.setExportTargetTable(exportTargetTable);
         bean.setImportTargetTable(importTargetTable);
@@ -388,7 +388,7 @@ public class LockReleaseTest {
         UnitTestUtil.executeUpdate(dup2Sql.toString());
 
         // ExportBeanを生成
-        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<String, ExportTargetTableBean>();
+        Map<String, ExportTargetTableBean> exportTargetTable = new LinkedHashMap<>();
         ExportTargetTableBean table1 = new ExportTargetTableBean();
         table1.setExportTempTableName(tempTable1);
         table1.setDuplicateFlagTableName("EXPORT_TEMP_TEST_01_DF");
@@ -397,7 +397,7 @@ public class LockReleaseTest {
         table2.setExportTempTableName(tempTable2);
         table2.setDuplicateFlagTableName("EXPORT_TEMP_TEST_02_DF");
         exportTargetTable.put("IMPORT_TARGET2", table2);
-        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> importTargetTable = new LinkedHashMap<>();
         ImportTargetTableBean table3 = new ImportTargetTableBean();
         importTargetTable.put("IMPORT_TARGET1", table3);
         ImportTargetTableBean table4 = new ImportTargetTableBean();

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/extractor/DfsFileImportTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/extractor/DfsFileImportTest.java
@@ -119,7 +119,7 @@ public class DfsFileImportTest {
     @Test
     public void importFileTest01() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("${execution_id}/import/XXX");
         tableBean1.setImportTargetType(this.getClass());
@@ -199,7 +199,7 @@ public class DfsFileImportTest {
     @Test
     public void importFileTest02() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("Dummy");
         tableBean1.setImportTargetType(this.getClass());
@@ -269,7 +269,7 @@ public class DfsFileImportTest {
     @Test
     public void create_cache() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
 
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("/${user}/${execution_id}/import/c1");
@@ -303,8 +303,8 @@ public class DfsFileImportTest {
         writer.close();
 
         final File output = folder.newFolder("output");
-        final List<String> files = new ArrayList<String>();
-        final List<String> builders = new ArrayList<String>();
+        final List<String> files = new ArrayList<>();
+        final List<String> builders = new ArrayList<>();
 
         // テスト対象クラス実行
         DummyHdfsFileImport fileImport = new DummyHdfsFileImport(0) {
@@ -367,7 +367,7 @@ public class DfsFileImportTest {
     @Test
     public void update_cache() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
 
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("/${user}/${execution_id}/import/c1");
@@ -401,8 +401,8 @@ public class DfsFileImportTest {
         writer.close();
 
         final File output = folder.newFolder("output");
-        final List<String> files = new ArrayList<String>();
-        final List<String> builders = new ArrayList<String>();
+        final List<String> files = new ArrayList<>();
+        final List<String> builders = new ArrayList<>();
 
         // テスト対象クラス実行
         DummyHdfsFileImport fileImport = new DummyHdfsFileImport(0) {
@@ -464,7 +464,7 @@ public class DfsFileImportTest {
     @Test
     public void extract_broken() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("/${user}/${execution_id}/import/XXX");
         tableBean1.setImportTargetType(ImportTarget1.class);
@@ -510,7 +510,7 @@ public class DfsFileImportTest {
     @Test
     public void importFileTest03() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("Dummy");
         tableBean1.setImportTargetType(this.getClass());
@@ -579,7 +579,7 @@ public class DfsFileImportTest {
     @Test
     public void importFileTest04() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("Dummy");
         tableBean1.setImportTargetType(this.getClass());
@@ -624,7 +624,7 @@ public class DfsFileImportTest {
     @Test
     public void importFileTest05() throws Exception {
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setDfsFilePath("/asakusa/import/XXX");
         tableBean1.setImportTargetType(this.getClass());

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportFileCreateTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportFileCreateTest.java
@@ -114,7 +114,7 @@ public class ImportFileCreateTest {
 //        String pattern = "patternC01";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);
@@ -172,7 +172,7 @@ public class ImportFileCreateTest {
         util.storeToDatabase(false);
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);
@@ -241,7 +241,7 @@ public class ImportFileCreateTest {
 //        String pattern = "patternC02";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -312,7 +312,7 @@ public class ImportFileCreateTest {
 //        String pattern = "patternC03";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"INTDATA1", "TEXTDATA1"}));
         tableBean1.setSearchCondition(null);
@@ -371,7 +371,7 @@ public class ImportFileCreateTest {
             fos.write(123);
 
             // ImportBeanを生成
-            Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+            Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
             ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
             tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"INTDATA1", "TEXTDATA1"}));
             tableBean1.setSearchCondition(null);
@@ -420,7 +420,7 @@ public class ImportFileCreateTest {
 //        String pattern = "patternC01";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);
@@ -470,7 +470,7 @@ public class ImportFileCreateTest {
 //        String pattern = "patternC01";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition("1 < 0");
@@ -520,7 +520,7 @@ public class ImportFileCreateTest {
 //        String pattern = "patternC01";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportFileDeleteTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportFileDeleteTest.java
@@ -99,7 +99,7 @@ public class ImportFileDeleteTest {
         importFile3.createNewFile();
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportFile(importFile1);
         targetTable.put("IMPORT_TARGET1", tableBean1);
@@ -141,7 +141,7 @@ public class ImportFileDeleteTest {
         File importFile3 = new File(dumpDir, "IMP_IMPORT_TARGET3.tsv");
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportFile(importFile1);
         targetTable.put("IMPORT_TARGET1", tableBean1);
@@ -181,7 +181,7 @@ public class ImportFileDeleteTest {
         File importFile3 = null;
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportFile(importFile1);
         targetTable.put("IMPORT_TARGET1", tableBean1);
@@ -226,7 +226,7 @@ public class ImportFileDeleteTest {
             fos.write(123);
 
             // ImportBeanを生成
-            Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+            Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
             ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
             tableBean1.setImportFile(importFile1);
             targetTable.put("IMPORT_TARGET1", tableBean1);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportFileSendTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportFileSendTest.java
@@ -109,7 +109,7 @@ public class ImportFileSendTest {
     public void sendImportFileTtest01() throws Exception {
         // ImportBeanを生成
         File importFile = new File("src/test/data/importer/IMP_IMPORT_TARGET1.tsv");
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportProtocol(FileList.content("dummy1"));
         tableBean.setImportFile(importFile);
@@ -153,7 +153,7 @@ public class ImportFileSendTest {
         // ImportBeanを生成
         File importFile1 = new File("src/test/data/importer/IMP_IMPORT_TARGET1.tsv");
         File importFile2 = new File("src/test/data/importer/IMP_IMPORT_TARGET2.tsv");
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportProtocol(FileList.content("dummy1"));
         tableBean1.setImportFile(importFile1);
@@ -199,7 +199,7 @@ public class ImportFileSendTest {
     public void sendImportFileTtest03() throws Exception {
         // ImportBeanを生成
         File importFile = new File("src/test/data/importer/IMP_IMPORT_TARGET2.tsv");
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportProtocol(FileList.content("dummy1"));
         tableBean.setImportFile(importFile);
@@ -238,7 +238,7 @@ public class ImportFileSendTest {
     public void sendImportFileTtest04() throws Exception {
         // ImportBeanを生成
         File importFile = new File("src/test/data/importer/IMP_IMPORT_TARGET99.tsv");
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportProtocol(FileList.content("dummy1"));
         tableBean.setImportFile(importFile);
@@ -269,7 +269,7 @@ public class ImportFileSendTest {
     public void sendImportFileTtest05() throws Exception {
         // ImportBeanを生成
         File importFile = new File("src/test/data/importer/IMP_IMPORT_TARGET1.tsv");
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportProtocol(FileList.content("dummy1"));
         tableBean.setImportFile(importFile);

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportProtocolDecideTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/ImportProtocolDecideTest.java
@@ -109,7 +109,7 @@ public class ImportProtocolDecideTest {
     @Test
     public void contents() throws Exception {
         ImportBean bean = createBean();
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId(null);
@@ -135,7 +135,7 @@ public class ImportProtocolDecideTest {
     public void create_cache() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -165,7 +165,7 @@ public class ImportProtocolDecideTest {
         assertThat(info.getFeatureVersion(), is(CacheInfo.FEATURE_VERSION));
         assertThat(info.getTimestamp(), is(not(nullValue())));
         assertThat(info.getTableName(), is("__TG_TEST1"));
-        assertThat(info.getColumnNames(), is((Object) new HashSet<String>(tb1.getImportTargetColumns())));
+        assertThat(info.getColumnNames(), is((Object) new HashSet<>(tb1.getImportTargetColumns())));
         assertThat(info.getModelClassName(), is(ImportTarget1.class.getName()));
         assertThat(info.getModelClassVersion(), is(new ImportTarget1().__tgc__DataModelVersion()));
     }
@@ -178,7 +178,7 @@ public class ImportProtocolDecideTest {
     public void update_cache() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -229,7 +229,7 @@ public class ImportProtocolDecideTest {
         assertThat(info.getFeatureVersion(), is(CacheInfo.FEATURE_VERSION));
         assertThat(info.getTimestamp(), is(not(nullValue())));
         assertThat(info.getTableName(), is("__TG_TEST1"));
-        assertThat(info.getColumnNames(), is((Object) new HashSet<String>(tb1.getImportTargetColumns())));
+        assertThat(info.getColumnNames(), is((Object) new HashSet<>(tb1.getImportTargetColumns())));
         assertThat(info.getModelClassName(), is(ImportTarget1.class.getName()));
         assertThat(info.getModelClassVersion(), is(new ImportTarget1().__tgc__DataModelVersion()));
     }
@@ -242,7 +242,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_rebuild() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -294,7 +294,7 @@ public class ImportProtocolDecideTest {
         assertThat(info.getFeatureVersion(), is(CacheInfo.FEATURE_VERSION));
         assertThat(info.getTimestamp(), is(not(nullValue())));
         assertThat(info.getTableName(), is("__TG_TEST1"));
-        assertThat(info.getColumnNames(), is((Object) new HashSet<String>(tb1.getImportTargetColumns())));
+        assertThat(info.getColumnNames(), is((Object) new HashSet<>(tb1.getImportTargetColumns())));
         assertThat(info.getModelClassName(), is(ImportTarget1.class.getName()));
         assertThat(info.getModelClassVersion(), is(new ImportTarget1().__tgc__DataModelVersion()));
     }
@@ -307,7 +307,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_db_rollback() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -359,7 +359,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_dfs_rollback() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -411,7 +411,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_broken_local() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -449,7 +449,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_broken_remote() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -494,7 +494,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_feature_changed() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -546,7 +546,7 @@ public class ImportProtocolDecideTest {
     public void update_cache_inconsistent_model() throws Exception {
         ImportBean bean = createBean();
 
-        Map<String, ImportTargetTableBean> targetTable = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new HashMap<>();
 
         final ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
@@ -597,7 +597,7 @@ public class ImportProtocolDecideTest {
     @Test
     public void conflict_lock() throws Exception {
         ImportBean bean1 = createBean();
-        Map<String, ImportTargetTableBean> targetTable1 = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable1 = new HashMap<>();
         ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
         tb1.setDfsFilePath("tb1");
@@ -608,7 +608,7 @@ public class ImportProtocolDecideTest {
         bean1.setTargetTable(targetTable1);
 
         ImportBean bean2 = createBean();
-        Map<String, ImportTargetTableBean> targetTable2 = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable2 = new HashMap<>();
         ImportTargetTableBean tb2 = new ImportTargetTableBean();
         tb2.setCacheId("tb1");
         tb2.setDfsFilePath("tb1");
@@ -641,7 +641,7 @@ public class ImportProtocolDecideTest {
     @Test
     public void release_lock() throws Exception {
         ImportBean bean1 = createBean();
-        Map<String, ImportTargetTableBean> targetTable1 = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable1 = new HashMap<>();
         ImportTargetTableBean tb1 = new ImportTargetTableBean();
         tb1.setCacheId("tb1");
         tb1.setDfsFilePath("tb1");
@@ -652,7 +652,7 @@ public class ImportProtocolDecideTest {
         bean1.setTargetTable(targetTable1);
 
         ImportBean bean2 = createBean();
-        Map<String, ImportTargetTableBean> targetTable2 = new HashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable2 = new HashMap<>();
         ImportTargetTableBean tb2 = new ImportTargetTableBean();
         tb2.setCacheId("tb1");
         tb2.setDfsFilePath("tb1");

--- a/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/TargetDataLockTest.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/com/asakusafw/bulkloader/importer/TargetDataLockTest.java
@@ -111,7 +111,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL01";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);
@@ -177,7 +177,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL02";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -243,7 +243,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL03";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition("TEXTDATA1='testdata1-2'");
@@ -312,7 +312,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL04";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean1 = new ImportTargetTableBean();
         tableBean1.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean1.setSearchCondition("INTDATA1=11");
@@ -370,7 +370,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL05";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);
@@ -428,7 +428,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL06";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA1", "INTDATA1", "DATEDATA1"}));
         tableBean.setSearchCondition(null);
@@ -486,7 +486,7 @@ public class TargetDataLockTest {
 //        String pattern = "patternL07";
 
         // ImportBeanを生成
-        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<String, ImportTargetTableBean>();
+        Map<String, ImportTargetTableBean> targetTable = new LinkedHashMap<>();
         ImportTargetTableBean tableBean = new ImportTargetTableBean();
         tableBean.setImportTargetColumns(Arrays.asList(new String[]{"TEXTDATA2"}));
         tableBean.setSearchCondition(null);

--- a/thundergate-project/asakusa-thundergate/src/test/java/test/modelgen/table/model/ImportTarget1.java
+++ b/thundergate-project/asakusa-thundergate/src/test/java/test/modelgen/table/model/ImportTarget1.java
@@ -55,6 +55,11 @@ import com.asakusafw.vocabulary.model.TableModel;
     }
 
     @Override
+    public long __tgc__Timestamp() {
+        return updtDate.get().getElapsedSeconds();
+    }
+
+    @Override
     public boolean __tgc__Deleted() {
         return false;
     }


### PR DESCRIPTION
## Summary

This commit enables old ThunderGate cache entries invalidate automatically.
## Background, Problem or Goal of the patch

ThunderGate always requires full table copy for its cache mechanism. But tables with historical data will become enlarged, and we sometimes access only recent data in such tables.
## Design of the fix, or a new feature

This feature is disabled in default. To enable this, clients must set invalidation timestamp and target table names into `asakusa-resources.xml` as the following properties.
- `com.asakusafw.thundergate.cache.invalidate.until=yyyy-MM-dd HH:mm:ss`
  - MAY remove records (exclusive) older than the specified timestamp
  - default: N/A (disabled)
- `com.asakusafw.thundergate.cache.invalidate.tables=<regex-table-names>`
  - target table names in regular expression
  - to apply this feature to all tables, please put `.+` explicitly
  - default: N/A (disabled)
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
