### PR TITLE
Should not respect findbugs exclude file in other repository.

### DIFF
--- a/legacy-project/asakusa-model-generator/pom.xml
+++ b/legacy-project/asakusa-model-generator/pom.xml
@@ -27,6 +27,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/conf/findbugs/exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/legacy-project/asakusa-model-generator/src/conf/findbugs/exclude.xml
+++ b/legacy-project/asakusa-model-generator/src/conf/findbugs/exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match classregex=".*\.ParseException"/>
+  <Match classregex=".*\.Jj.*"/>
+  <Match classregex=".*\.SimpleCharStream"/>
+</FindBugsFilter>

--- a/legacy-project/asakusa-test-tools/pom.xml
+++ b/legacy-project/asakusa-test-tools/pom.xml
@@ -24,6 +24,13 @@
           <testFailureIgnore>true</testFailureIgnore>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/conf/findbugs/exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/legacy-project/asakusa-test-tools/src/conf/findbugs/exclude.xml
+++ b/legacy-project/asakusa-test-tools/src/conf/findbugs/exclude.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match class="com.asakusafw.testtools.TestDataHolder">
+    <Or>
+      <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"/>
+    </Or>
+  </Match>
+  <Match class="com.asakusafw.testtools.db.DbUtils">
+    <Or>
+      <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
+    </Or>
+  </Match>
+  <Match class="com.asakusafw.testtools.templategen.ExcelBookBuilder">
+    <Or>
+      <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"/>
+    </Or>
+  </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,6 @@ encoding/<project>=UTF-8
           <configuration>
             <xmlOutput>true</xmlOutput>
             <findbugsXmlOutput>true</findbugsXmlOutput>
-            <excludeFilterFile>com/asakusafw/fb_exclude.xml</excludeFilterFile>
             <sourceEncoding>UTF-8</sourceEncoding>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>
@@ -531,7 +530,6 @@ encoding/<project>=UTF-8
         <configuration>
           <xmlOutput>true</xmlOutput>
           <findbugsXmlOutput>true</findbugsXmlOutput>
-          <excludeFilterFile>com/asakusafw/fb_exclude.xml</excludeFilterFile>
           <sourceEncoding>UTF-8</sourceEncoding>
           <outputEncoding>UTF-8</outputEncoding>
         </configuration>

--- a/thundergate-project/asakusa-thundergate-dmdl/pom.xml
+++ b/thundergate-project/asakusa-thundergate-dmdl/pom.xml
@@ -26,6 +26,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/conf/findbugs/exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/thundergate-project/asakusa-thundergate-dmdl/src/conf/findbugs/exclude.xml
+++ b/thundergate-project/asakusa-thundergate-dmdl/src/conf/findbugs/exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match classregex=".*\.ParseException"/>
+  <Match classregex=".*\.Jj.*"/>
+  <Match classregex=".*\.SimpleCharStream"/>
+</FindBugsFilter>

--- a/thundergate-project/asakusa-thundergate-plugin/pom.xml
+++ b/thundergate-project/asakusa-thundergate-plugin/pom.xml
@@ -11,6 +11,18 @@
 
   <packaging>jar</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/conf/findbugs/exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/thundergate-project/asakusa-thundergate-plugin/src/conf/findbugs/exclude.xml
+++ b/thundergate-project/asakusa-thundergate-plugin/src/conf/findbugs/exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match class="com.asakusafw.compiler.bulkloader.BulkLoaderIoProcessor$CommandProvider">
+    <Bug pattern="SE_BAD_FIELD"/>
+  </Match>
+</FindBugsFilter>

--- a/thundergate-project/asakusa-thundergate/pom.xml
+++ b/thundergate-project/asakusa-thundergate/pom.xml
@@ -42,6 +42,13 @@
           <testFailureIgnore>true</testFailureIgnore>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/conf/findbugs/exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/thundergate-project/asakusa-thundergate/src/conf/findbugs/exclude.xml
+++ b/thundergate-project/asakusa-thundergate/src/conf/findbugs/exclude.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match class="com.asakusafw.bulkloader.exporter.ExportFileLoad">
+    <Or>
+      <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"/>
+    </Or>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Summary

This commit migrates FindBugs exclusion file in `asakusafw/build-tools` into individual projects.
## Background, Problem or Goal of the patch

Previously, projects under this repository has been referred  the FindBugs exclusion file in `asakusafw/build-tools`. This may prevents changing upstream the exclusion file, or introducing unavoidable ill-mannered snippet into this repository.
## Design of the fix, or a new feature

This commit stops referring the exclusion file on the upstream repository, and put minimized one into individual projects.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
