### PR TITLE
Enable table join on updating ThunderGate caches.

### DIFF
--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/MergeJoinBaseMapper.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/MergeJoinBaseMapper.java
@@ -26,7 +26,7 @@ import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
  * Mapper class for base (which should be applied patches) input.
  * @since 0.2.3
  */
-public class BaseMapper extends Mapper<
+public class MergeJoinBaseMapper extends Mapper<
         NullWritable, ThunderGateCacheSupport,
         PatchApplyKey, ThunderGateCacheSupport> {
 

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/MergeJoinPatchMapper.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/MergeJoinPatchMapper.java
@@ -26,7 +26,7 @@ import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
  * Mapper class for base input.
  * @since 0.2.3
  */
-public class PatchMapper extends Mapper<
+public class MergeJoinPatchMapper extends Mapper<
         NullWritable, ThunderGateCacheSupport,
         PatchApplyKey, ThunderGateCacheSupport> {
 

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/MergeJoinReducer.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/MergeJoinReducer.java
@@ -27,7 +27,7 @@ import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
  * Reducer class for ThunderGate Cache merging.
  * @since 0.2.3
  */
-public class PatchApplyReducer extends Reducer<
+public class MergeJoinReducer extends Reducer<
         PatchApplyKey, ThunderGateCacheSupport,
         NullWritable, ThunderGateCacheSupport> {
 

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/PatchApplyKey.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/PatchApplyKey.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.io.WritableUtils;
 import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
 
 /**
- * Shuffle key object for {@link PatchApplyReducer}.
+ * Shuffle key object for {@link MergeJoinReducer}.
  * @since 0.2.3
  */
 public class PatchApplyKey implements WritableComparable<PatchApplyKey> {

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/PatchStrategy.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/PatchStrategy.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.thundergate.runtime.cache.mapreduce;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileStatus;
+
+import com.asakusafw.runtime.stage.temporary.TemporaryStorage;
+import com.asakusafw.thundergate.runtime.cache.CacheStorage;
+
+/**
+ * Utilities about merge strategy.
+ * @since 0.8.1
+ */
+public final class PatchStrategy {
+
+    static final Log LOG = LogFactory.getLog(PatchStrategy.class);
+
+    /**
+     * The Hadoop configuration key of maximum patch size of table join strategy.
+     */
+    public static final String KEY_TABLE_JOIN_LIMIT = "com.asakusafw.thundergate.cache.tablejoin.limit";
+
+    /**
+     * The default value of {@link #KEY_TABLE_JOIN_LIMIT}.
+     */
+    public static final long DEFAULT_TABLE_JOIN_LIMIT = -1L;
+
+    private PatchStrategy() {
+        return;
+    }
+
+    /**
+     * Returns whether or not the table join is enabled for the target cache.
+     * @param tableName the table name
+     * @param cache the target cache.
+     * @return {@code true} if the table join is enabled, otherwise {@code false}
+     */
+    public static boolean isTableJoin(String tableName, CacheStorage cache) {
+        long limit = cache.getConfiguration().getLong(KEY_TABLE_JOIN_LIMIT, DEFAULT_TABLE_JOIN_LIMIT);
+        if (limit <= 0) {
+            LOG.info(MessageFormat.format(
+                    "cache table join is disabled: {0}",
+                    tableName));
+            return false;
+        }
+        LOG.info(MessageFormat.format("computing patch content size: {0}",
+                tableName));
+        try {
+            long total = 0;
+            for (FileStatus stat : TemporaryStorage.listStatus(
+                    cache.getConfiguration(), cache.getPatchContents("*"))) {
+                total += stat.getLen();
+            }
+            LOG.info(MessageFormat.format("patch content size: {1}bytes (table-join-limit={2}, {0})",
+                    tableName,
+                    total,
+                    limit));
+            return total <= limit;
+        } catch (IOException e) {
+            LOG.warn(MessageFormat.format(
+                    "failed to compute patch size: {0}",
+                    tableName), e);
+            return false;
+        }
+    }
+}

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/TableJoinBaseMapper.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/TableJoinBaseMapper.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.thundergate.runtime.cache.mapreduce;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import com.asakusafw.runtime.io.ModelInput;
+import com.asakusafw.runtime.stage.resource.StageResourceDriver;
+import com.asakusafw.runtime.stage.temporary.TemporaryStorage;
+import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
+
+/**
+ * Patcher with distributed cache.
+ * @since 0.8.1
+ */
+public class TableJoinBaseMapper extends Mapper<
+        NullWritable, ThunderGateCacheSupport,
+        NullWritable, ThunderGateCacheSupport> {
+
+    static final Log LOG = LogFactory.getLog(TableJoinBaseMapper.class);
+
+    /**
+     * The resource key name.
+     */
+    public static final String RESOURCE_KEY = "patch";
+
+    private Set<LongWritable> conflicts;
+
+    private final LongWritable buffer = new LongWritable();
+
+    private long invalidate;
+
+    @Override
+    protected void setup(Context context) throws IOException, InterruptedException {
+        super.setup(context);
+        this.conflicts = buildConflicts(context, context.getOutputValueClass().asSubclass(Writable.class));
+        this.invalidate = Invalidation.getInvalidationTimestamp(context.getConfiguration());
+    }
+
+    private static <T extends Writable> Set<LongWritable> buildConflicts(
+            Context context, Class<T> dataType) throws IOException {
+        Configuration conf = context.getConfiguration();
+        List<Path> caches = getPatchPaths(context);
+        T buffer = ReflectionUtils.newInstance(dataType, conf);
+        Set<LongWritable> results = new HashSet<>();
+        for (Path path : caches) {
+            try (ModelInput<T> input = TemporaryStorage.openInput(conf, dataType, path)) {
+                while (input.readTo(buffer)) {
+                    results.add(new LongWritable(((ThunderGateCacheSupport) buffer).__tgc__SystemId()));
+                }
+            }
+        }
+        return results;
+    }
+
+    private static List<Path> getPatchPaths(Context context) throws IOException {
+        try (StageResourceDriver driver = new StageResourceDriver(context.getConfiguration())) {
+            return driver.findCache(RESOURCE_KEY);
+        }
+    }
+
+    @Override
+    protected void map(
+            NullWritable key,
+            ThunderGateCacheSupport value,
+            Context context) throws IOException, InterruptedException {
+        buffer.set(value.__tgc__SystemId());
+        if (value.__tgc__Deleted() == false
+                && conflicts.contains(buffer) == false
+                && Invalidation.isStillValid(value, invalidate)) {
+            context.write(key, value);
+        }
+    }
+}

--- a/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/TableJoinPatchMapper.java
+++ b/thundergate-project/asakusa-thundergate-runtime/src/main/java/com/asakusafw/thundergate/runtime/cache/mapreduce/TableJoinPatchMapper.java
@@ -23,27 +23,19 @@ import org.apache.hadoop.mapreduce.Mapper;
 import com.asakusafw.thundergate.runtime.cache.ThunderGateCacheSupport;
 
 /**
- * Logical deleted filter.
- * @since 0.2.3
+ * Logical deleted filter for patches.
+ * @since 0.8.1
  */
-public class DeleteMapper extends Mapper<
+public class TableJoinPatchMapper extends Mapper<
         NullWritable, ThunderGateCacheSupport,
         NullWritable, ThunderGateCacheSupport> {
-
-    private long invalidate;
-
-    @Override
-    protected void setup(Context context) throws IOException, InterruptedException {
-        super.setup(context);
-        this.invalidate = Invalidation.getInvalidationTimestamp(context.getConfiguration());
-    }
 
     @Override
     protected void map(
             NullWritable key,
             ThunderGateCacheSupport value,
             Context context) throws IOException, InterruptedException {
-        if (value.__tgc__Deleted() == false && Invalidation.isStillValid(value, invalidate)) {
+        if (value.__tgc__Deleted() == false) {
             context.write(key, value);
         }
     }


### PR DESCRIPTION
## Summary

This PR enables map-side joins on updating ThunderGate caches.
## Background, Problem or Goal of the patch

The previous implementation always performs reduce-side (sorted merge) join for updating caches. This algorithm is not so good if patch data is considerably smaller than the original data; but almost patches are so small.
## Design of the fix, or a new feature

This introduces the following Hadoop configuration:
- `com.asakusafw.thundergate.cache.tablejoin.limit=size-in-bytes`
  - maximum patch size of table join strategy is enabled
  - default: `-1` (always disabled)

If the patch data is smaller than the specified size, the cache builder will put them onto the Hadoop distributed cache. And then the mappers extracts a set of `SID`s from the cache. So that each mapper task must have enough memory to build the SID set.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
