### PR TITLE
Fix dupcheck with union type models.

### DIFF
--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/BulkLoadExporterRetriever.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/BulkLoadExporterRetriever.java
@@ -139,7 +139,7 @@ public class BulkLoadExporterRetriever extends AbstractExporterRetriever<BulkLoa
         DuplicateRecordCheck dupcheck = description.getDuplicateRecordCheck();
         if (dupcheck != null && modelClass == dupcheck.getTableModelClass()) {
             return false;
-        } else if (modelClass == description.getTableModelClass()) {
+        } else if (modelClass == description.getModelType() || modelClass == description.getTableModelClass()) {
             return true;
         } else {
             throw new IOException(MessageFormat.format(

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableSourceProvider.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableSourceProvider.java
@@ -62,14 +62,14 @@ public class TableSourceProvider implements DataModelSourceProvider {
 
         Configuration conf = Configuration.load(targetName);
         Connection conn = null;
-        ResultSet res = null;
         try {
             conn = conf.open();
             DatabaseMetaData meta = conn.getMetaData();
-            res = meta.getColumns(null, null, tableName, "%");
             List<String> columnList = new ArrayList<>();
-            while (res.next()) {
-                columnList.add(res.getString("COLUMN_NAME"));
+            try (ResultSet res = meta.getColumns(null, null, tableName, "%")) {
+                while (res.next()) {
+                    columnList.add(res.getString("COLUMN_NAME"));
+                }
             }
             TableInfo<T> table = new TableInfo<>(definition, tableName, columnList);
             return new TableSource<>(table, conn);

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/DupCheck.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/DupCheck.java
@@ -25,7 +25,6 @@ import com.asakusafw.vocabulary.bulkloader.PrimaryKey;
 
 /**
  * A simple data model.
- * @since 0.2.0
  */
 @PrimaryKey("number")
 @OriginalName("DUP_CHECK")

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2Resource.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2Resource.java
@@ -149,9 +149,8 @@ public class H2Resource extends TestWatcher {
     }
 
     private List<List<Object>> query0(String sql) throws SQLException {
-        Statement s = connection.createStatement();
-        try {
-            ResultSet rs = s.executeQuery(sql);
+        try (Statement s = connection.createStatement();
+                ResultSet rs = s.executeQuery(sql)) {
             ResultSetMetaData meta = rs.getMetaData();
             int size = meta.getColumnCount();
             List<List<Object>> results = new ArrayList<>();
@@ -163,8 +162,6 @@ public class H2Resource extends TestWatcher {
                 results.add(Arrays.asList(columns));
             }
             return results;
-        } finally {
-            s.close();
         }
     }
 

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2ResourceTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/H2ResourceTest.java
@@ -72,8 +72,8 @@ public class H2ResourceTest {
         h2.execute("INSERT INTO TESTING (NUMBER, TEXT) VALUES(100, 'Hello, world!')");
 
         try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test");
-                Statement stmt = conn.createStatement()) {
-            ResultSet rs = stmt.executeQuery("SELECT NUMBER, TEXT FROM TESTING");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT NUMBER, TEXT FROM TESTING")) {
             assertThat(rs.next(), is(true));
             assertThat(rs.getObject(1), is((Object) 100));
             assertThat(rs.getObject(2), is((Object) "Hello, world!"));

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableSourceProviderTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableSourceProviderTest.java
@@ -134,10 +134,10 @@ public class TableSourceProviderTest {
     @Test
     public void invalid_scheme() throws Exception {
         context.put("provider", "provider");
-
         TableSourceProvider provider = new TableSourceProvider();
-        DataModelSource source = provider.open(SIMPLE, new URI("hoge:provider:SIMPLE"), new TestContext.Empty());
-        assertThat(source, is(nullValue()));
+        try (DataModelSource source = provider.open(SIMPLE, new URI("hoge:provider:SIMPLE"), new TestContext.Empty())) {
+            assertThat(source, is(nullValue()));
+        }
     }
 
     private <T> void insert(T simple, DataModelDefinition<T> def, String table) {

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/Union.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/Union.java
@@ -42,7 +42,7 @@ import com.asakusafw.vocabulary.bulkloader.PrimaryKey;
     "C_TIME",
     "C_DATETIME"
 })
-public class Simple {
+public class Union {
 
     /**
      * int.
@@ -152,7 +152,7 @@ public class Simple {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        Simple other = (Simple) obj;
+        Union other = (Union) obj;
         if (bigDecimalValue == null) {
             if (other.bigDecimalValue != null) {
                 return false;
@@ -249,6 +249,6 @@ public class Simple {
 
     @Override
     public String toString() {
-        return new SimpleDataModelDefinition<>(Simple.class).toReflection(this).toString();
+        return new SimpleDataModelDefinition<>(Union.class).toReflection(this).toString();
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes ThunderGate test moderator.
## Background, Problem or Goal of the patch

In the latest implementation, the test moderator rejects union types in `DupCheckDbExporterDescription`.
## Design of the fix, or a new feature

`BulkLoadExporterRetriever` now also accepts `DupCheckDbExporterDescription.getModelType()` (may be a `union type`) instead of only `DupCheckDbExporterDescription.getNormalModelType()`.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
