### PR TITLE
Keep explicit timestamp value in TG tests.

### DIFF
--- a/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableOutput.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/main/java/com/asakusafw/testdriver/bulkloader/TableOutput.java
@@ -137,15 +137,22 @@ public class TableOutput<T> implements ModelOutput<T> {
             statement.clearParameters();
             index = 1;
             String timestamp = table.getTimestampColumn();
+            Timestamp timestampValue = new Timestamp(0L);
             DataModelDefinition<?> def = table.getDefinition();
             for (Map.Entry<String, PropertyName> entry : table.getColumnsToProperties().entrySet()) {
-                if (entry.getKey().equals(timestamp) == false) {
+                if (entry.getKey().equals(timestamp)) {
+                    Calendar value = (Calendar) ref.getValue(entry.getValue());
+                    if (value != null) {
+                        timestampValue = new Timestamp(value.getTimeInMillis());
+                    }
+                } else {
                     scan(def, entry.getValue(), ref);
                     index++;
                 }
             }
+            // timestamp column (a.k.a. UPDT_DATE) must not be NULL for ThunderGate Cache
             if (timestamp != null) {
-                statement.setTimestamp(index, new Timestamp(0L));
+                statement.setTimestamp(index, timestampValue);
             }
             statement.executeUpdate();
         }

--- a/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableOutputTest.java
+++ b/thundergate-project/asakusa-thundergate-test-moderator/src/test/java/com/asakusafw/testdriver/bulkloader/TableOutputTest.java
@@ -259,7 +259,7 @@ public class TableOutputTest {
         assertThat(results.size(), is(1));
         Timestamp timestamp = (Timestamp) results.get(0).get(0);
         assertThat(timestamp, is(notNullValue()));
-        assertThat(timestamp.getTime(), is(0L));
+        assertThat("should keep explicit timestamp values", timestamp.getTime(), is(1L));
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR enables to keep explicit timestamp column (a.k.a. `UPDT_DATETIME`) values in the ThunderGate test moderator.
## Background, Problem or Goal of the patch

The latest implementation always use the epoch time (`1970-01-01 00:00:00`) as timestamp column value even if there is explicit value exists. This is nothing but for avoiding `NULL` for its column for ThunderGate cache mechanism.
## Design of the fix, or a new feature

This now keeps explicit timestamp column values on test sheets, and set the epoch time only if they are not specified.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
